### PR TITLE
Supercollider docker images

### DIFF
--- a/docker/build.yml
+++ b/docker/build.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+    # Supercollider on Fedora 34
+    supercollider:
+        build:
+            context: ./supercollider
+            dockerfile: Dockerfile
+        image: "supercollider:latest"
+    
+    # Supercollider on Alpine Linux (smaller image)
+    supercollider-alpine:
+        build:
+            context: ./supercollider-alpine
+            dockerfile: Dockerfile
+        image: "supercollider:alpine"
+    
+    # Supercollider on Alpine with extra UGens and Quarks
+    supercollider-extra:
+        build:
+            context: ./supercollider-extra
+            dockerfile: Dockerfile
+        image: "supercollider-extra:3.11.1"

--- a/docker/supercollider-alpine/Dockerfile
+++ b/docker/supercollider-alpine/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:latest
+# Default to latest version of supercollider
+ARG VERSION=develop
+
+RUN apk add --no-cache git g++ cmake make pipewire pipewire-jack libsndfile-dev fftw-dev jack-dev avahi-dev readline-dev linux-headers
+
+# Despite the files being present, the cmake script fails to find them without this
+RUN ln -sf /usr/lib/pipewire-0.3/jack/libjack.* /usr/lib
+
+WORKDIR temp
+
+# Latest release is on main branch
+# Build with fewer features for a smaller install
+RUN git clone --depth=1 --shallow-submodules --branch $VERSION --recursive https://github.com/supercollider/supercollider.git && \
+    cd supercollider && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DENABLE_TESTSUITE=OFF -DSUPERNOVA=OFF -DNATIVE=OFF -DNO_X11=ON -DSC_EL=OFF -DSC_VIM=OFF -DSC_QT=OFF -DSC_HIDAPI=OFF -DSC_IDE=OFF -DSC_ED=OFF -DSC_ABLETON_LINK=OFF -DINSTALL_HELP=OFF && \
+    make && \
+    make install && \
+    rm -rf /temp
+
+EXPOSE 57110:57110/udp
+
+RUN adduser --system sclang audio
+
+WORKDIR /tmp/sc
+
+COPY ./entrypoint /run/
+RUN chmod +x /run/entrypoint && \
+    chown sclang:audio /run/entrypoint && \
+    chown -R sclang:audio /tmp/sc
+
+USER sclang
+
+ENTRYPOINT ["/run/entrypoint"]

--- a/docker/supercollider-alpine/entrypoint
+++ b/docker/supercollider-alpine/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/usr/bin/pipewire &
+
+exec "$@"

--- a/docker/supercollider-extra/Dockerfile
+++ b/docker/supercollider-extra/Dockerfile
@@ -1,10 +1,12 @@
 FROM supercollider:alpine
 ARG VERSION=Version-3.11.1
 
-# Install sc3-plugins
-
 USER root
 
+# Wanted by MP3
+RUN apk add --no-cache vorbis-tools curl
+
+# Install sc3-plugins
 WORKDIR /temp
 RUN git clone --depth=1 --shallow-submodules --recursive --branch $VERSION https://github.com/supercollider/sc3-plugins.git && \
     cd sc3-plugins && \
@@ -17,8 +19,18 @@ USER sclang
 WORKDIR /tmp/sc
 
 COPY quarks_install.scd /tmp/sc/quarks_install.scd
-
 RUN sclang quarks_install.scd
 RUN rm quarks_install.scd
-    
+
+# Remove graphics dependencies of ATK-SC3
+# https://github.com/ambisonictoolkit/atk-sc3/issues/100
+RUN rm -rf ~/.local/share/SuperCollider/downloaded-quarks/PointView \
+    ~/.local/share/SuperCollider/downloaded-quarks/wslib/wslib-classes/GUI \
+    ~/.local/share/SuperCollider/downloaded-quarks/wslib/wslib-classes/Main\ Features/Interpolation/extPen-splineCurve.sc \
+    ~/.local/share/SuperCollider/downloaded-quarks/wslib/wslib-classes/Main\ Features/SVGFile/
+
+COPY atk_install.scd /tmp/sc/atk_install.scd
+RUN sclang atk_install.scd
+RUN rm atk_install.scd
+
 ENTRYPOINT ["/run/entrypoint"]

--- a/docker/supercollider-extra/Dockerfile
+++ b/docker/supercollider-extra/Dockerfile
@@ -1,0 +1,24 @@
+FROM supercollider:alpine
+ARG VERSION=Version-3.11.1
+
+# Install sc3-plugins
+
+USER root
+
+WORKDIR /temp
+RUN git clone --depth=1 --shallow-submodules --recursive --branch $VERSION https://github.com/supercollider/sc3-plugins.git && \
+    cd sc3-plugins && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DSUPERNOVA=OFF -DLADSPA=ON && \
+    make && \
+    make install && \
+    rm -rf /temp
+
+USER sclang
+WORKDIR /tmp/sc
+
+COPY quarks_install.scd /tmp/sc/quarks_install.scd
+
+RUN sclang quarks_install.scd
+RUN rm quarks_install.scd
+    
+ENTRYPOINT ["/run/entrypoint"]

--- a/docker/supercollider-extra/atk_install.scd
+++ b/docker/supercollider-extra/atk_install.scd
@@ -1,5 +1,7 @@
 Atk.downloadKernels(action: {
     Atk.downloadMatrices(action: {
-        0.exit;
+        Atk.downloadSounds(action: {
+            0.exit;
+        });
     });
 });

--- a/docker/supercollider-extra/atk_install.scd
+++ b/docker/supercollider-extra/atk_install.scd
@@ -1,0 +1,5 @@
+Atk.downloadKernels(action: {
+    Atk.downloadMatrices(action: {
+        0.exit;
+    });
+});

--- a/docker/supercollider-extra/quarks_install.scd
+++ b/docker/supercollider-extra/quarks_install.scd
@@ -1,0 +1,3 @@
+Quarks.install("https://github.com/supercollider-quarks/MP3.git");
+Quarks.install("https://github.com/ambisonictoolkit/atk-sc3.git");
+0.exit;

--- a/docker/supercollider-extra/quarks_install.scd
+++ b/docker/supercollider-extra/quarks_install.scd
@@ -1,3 +1,4 @@
 Quarks.install("https://github.com/supercollider-quarks/MP3.git");
 Quarks.install("https://github.com/ambisonictoolkit/atk-sc3.git");
+Quarks.uninstall("PointView");
 0.exit;

--- a/docker/supercollider/Dockerfile
+++ b/docker/supercollider/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora:34
+ARG VERSION=develop
+
+RUN dnf install -q -y pipewire git cmake gcc-c++ pipewire-jack-audio-connection-kit-devel fftw-devel libsndfile-devel avahi-devel readline-devel && \
+    rm -rf /var/cache/dnf
+
+# Despite the files being present, the cmake script fails to find them without this
+RUN ln -s /usr/lib64/pipewire-0.3/jack/libjack.* /usr/lib64
+
+WORKDIR temp
+
+# Latest release is on main branch
+# Build with fewer features for a smaller install
+RUN git clone --branch $VERSION --recursive --depth=1 --shallow-submodules https://github.com/supercollider/supercollider.git && \
+    cd supercollider && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DENABLE_TESTSUITE=OFF -DSUPERNOVA=OFF -DNATIVE=OFF -DNO_X11=ON -DSC_EL=OFF -DSC_VIM=OFF -DSC_QT=OFF -DSC_HIDAPI=OFF -DSC_IDE=OFF -DSC_ED=OFF -DINSTALL_HELP=OFF && \
+    make && \
+    make install && \
+    rm -rf /temp
+
+EXPOSE 57110:57110/udp
+
+WORKDIR /tmp/sc
+
+RUN useradd -G audio sclang
+
+WORKDIR /tmp/sc
+
+COPY ./entrypoint /run/
+RUN chmod +x /run/entrypoint && \
+    chown sclang:audio /run/entrypoint && \
+    chown -R sclang:audio /tmp/sc
+
+USER sclang
+
+ENTRYPOINT ["/run/entrypoint"]

--- a/docker/supercollider/entrypoint
+++ b/docker/supercollider/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/usr/bin/pipewire &
+
+exec "$@"


### PR DESCRIPTION
Add Dockerfiles and a compose file to build three Supercollider images, all with the most recent develop version of Supercollider. All three use [PipeWire](https://pipewire.org/) as the underlying audio library and do not require attaching an audio card or privileged mode.

1. `supercollider:latest` is built with Fedora 34. It is a bit bigger in size, but is probably the easiest to develop on (694 MB).
2. `supercollider:alpine` is built with Alpine Linux so it is a bit smaller (444 MB).
3. `supercollider-extra` uses `supercollider:alpine` but also adds [sc3-plugins](https://github.com/supercollider/sc3-plugins) and a few Quarks (~485~ 557 MB).

These should probably be actually distributed eventually since they might be useful to others. Resolves #6.