### PR TITLE
Create optional field for image source URL

### DIFF
--- a/request.schema.json
+++ b/request.schema.json
@@ -24,7 +24,7 @@
         "imageSource": {
             "description": "The URL of the image, if one was available.",
             "type": "string",
-            "pattern": "^data:image/[^;]+;base64,[a-zA-Z0-9+/=]+$"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
         },
         "context": {
             "description": "Serialized XML of the image node and possibly related nodes.",

--- a/request.schema.json
+++ b/request.schema.json
@@ -21,6 +21,11 @@
             ],
             "additionalItems": false
         },
+        "imageSource": {
+            "description": "The URL of the image, if one was available.",
+            "type": "string",
+            "pattern": "^data:image/[^;]+;base64,[a-zA-Z0-9+/=]+$"
+        },
         "context": {
             "description": "Serialized XML of the image node and possibly related nodes.",
             "type": "string"


### PR DESCRIPTION
This may be useful in identifying images in practice, but is left optional since images may be created on-the-fly or otherwise might not have a useful URL.