### PR TITLE
Espnet cache

### DIFF
--- a/services/espnet-tts/src/app.py
+++ b/services/espnet-tts/src/app.py
@@ -22,13 +22,14 @@ with open("segment.response.json", "r") as f:
 
 app = Flask(__name__)
 
+
 @app.route("/service/tts/simple", methods=["POST"])
 def perform_tts():
     data = request.get_json()
     if data is None or "text" not in data:
-        return { "error": "Missing key \"text\"." }, 400
+        return {"error": "Missing key \"text\"."}, 400
     elif not isinstance(data["text"], str):
-        return { "error": "Key \"text\" must be of type string." }, 400
+        return {"error": "Key \"text\" must be of type string."}, 400
     text = data["text"]
     try:
         wav = tts(text)
@@ -39,7 +40,8 @@ def perform_tts():
         return Response(wrapper, mimetype="audio/wav", direct_passthrough=True)
     except Exception as e:
         logger.error(e)
-        return { "error": "An error occurred while performing text-to-speech" }, 500
+        return {"error": "An error occurred while performing text-to-speech"}, 500
+
 
 @app.route("/service/tts/segments", methods=["POST"])
 def segment_tts():
@@ -50,7 +52,7 @@ def segment_tts():
         validate(instance=data, schema=segment_request)
     except jsonschema.exceptions.ValidationError as e:
         logger.error(e)
-        return { "error": e.message }, 400
+        return {"error": e.message}, 400
 
     # TTS
     try:
@@ -80,4 +82,4 @@ def segment_tts():
         return response
     except Exception as e:
         logger.error(e)
-        return { "error": "An error occurred while performing text-to-speech" }, 500
+        return {"error": "An error occurred while performing text-to-speech"}, 500

--- a/services/espnet-tts/src/app.py
+++ b/services/espnet-tts/src/app.py
@@ -56,7 +56,7 @@ def segment_tts():
     try:
         totalWav = None
         durations = []
-        wavs = tts_segments(data["segments"])
+        wavs = [tts(segment) for segment in data["segments"]]
         for wav in wavs:
             if totalWav is not None:
                 totalWav = np.append(totalWav, wav)

--- a/services/espnet-tts/src/app.py
+++ b/services/espnet-tts/src/app.py
@@ -4,7 +4,7 @@ import jsonschema
 import logging
 import numpy as np
 import soundfile as sf
-from espnet_util import tts, tts_segments, fs
+from espnet_util import tts, fs
 from flask import Flask, Response, request
 from io import BytesIO
 from jsonschema import validate

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -9,32 +9,35 @@ from parallel_wavegan.utils import download_pretrained_model
 from parallel_wavegan.utils import load_model
 
 fs = 22050
+tag = "kan-bayashi/ljspeech_conformer_fastspeech2"
+vocoder_tag = "ljspeech_parallel_wavegan.v1"
 
 logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-@lru_cache
-def tts(text, tag = "kan-bayashi/ljspeech_conformer_fastspeech2", vocoder_tag = "ljspeech_parallel_wavegan.v1"):
-    d = ModelDownloader()
-    device = environ["TORCH_DEVICE"]
-    logger.info(f"Device: {device}")
-    text2speech = Text2Speech(
-            **d.download_and_unpack(tag),
-            device=device,
-            threshold=0.5,
-            minlenratio=0.0,
-            maxlenratio=10.0,
-            use_att_constraint=False,
-            backward_window=1,
-            forward_window=3,
-            # Only for FastSpeech & FastSpeech2
-            speed_control_alpha=1.0,
-    )
-    text2speech.spc2wav = None
-    vocoder = load_model(download_pretrained_model(vocoder_tag)).to(device).eval()
-    vocoder.remove_weight_norm()
+d = ModelDownloader()
+device = environ["TORCH_DEVICE"]
+logger.info(f"Device: {device}")
+text2speech = Text2Speech(
+        **d.download_and_unpack(tag),
+        device=device,
+        threshold=0.5,
+        minlenratio=0.0,
+        maxlenratio=10.0,
+        use_att_constraint=False,
+        backward_window=1,
+        forward_window=3,
+        # Only for FastSpeech & FastSpeech2
+        speed_control_alpha=1.0,
+)
+text2speech.spc2wav = None
+vocoder = load_model(download_pretrained_model(vocoder_tag)).to(device).eval()
+vocoder.remove_weight_norm()
 
+
+@lru_cache
+def tts(text):
     with torch.no_grad():
         start = time.time()
         wav, c, *_ = text2speech(text)
@@ -42,34 +45,3 @@ def tts(text, tag = "kan-bayashi/ljspeech_conformer_fastspeech2", vocoder_tag = 
     rtf = (time.time() - start) / (len(wav) / fs)
     logger.info(f"RTF: {rtf}")
     return wav.view(-1).cpu().numpy()
-
-def tts_segments(segments, tag = "kan-bayashi/ljspeech_conformer_fastspeech2", vocoder_tag = "ljspeech_parallel_wavegan.v1"):
-    d = ModelDownloader()
-    device = environ["TORCH_DEVICE"]
-    logger.info(f"Device: {device}")
-    text2speech = Text2Speech(
-            **d.download_and_unpack(tag),
-            device=device,
-            threshold=0.5,
-            minlenratio=0.0,
-            maxlenratio=10.0,
-            use_att_constraint=False,
-            backward_window=1,
-            forward_window=3,
-            # Only for FastSpeech & FastSpeech2
-            speed_control_alpha=1.0,
-    )
-    text2speech.spc2wav = None
-    vocoder = load_model(download_pretrained_model(vocoder_tag)).to(device).eval()
-    vocoder.remove_weight_norm()
-
-    with torch.no_grad():
-        start = time.time()
-        wavs = []
-        for segment in segments:
-            wav, c, *_ = text2speech(segment)
-            wav = vocoder.inference(c)
-            wavs.append(wav.view(-1).cpu().numpy())
-    rtf = (time.time() - start) / (reduce(lambda a, b: a+b, map(lambda x: len(x), wavs)) / fs)
-    logger.info(f"RTF: {rtf}")
-    return wavs

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -10,7 +10,8 @@ from parallel_wavegan.utils import load_model
 
 fs = 22050
 tag = "kan-bayashi/ljspeech_conformer_fastspeech2"
-vocoder_tag = "ljspeech_parallel_wavegan.v1"
+#vocoder_tag = "ljspeech_parallel_wavegan.v3"
+vocoder_tag = "ljspeech_full_band_melgan.v2"
 
 logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -41,7 +42,11 @@ def tts(text):
     with torch.no_grad():
         start = time.time()
         wav, c, *_ = text2speech(text)
+        t2 = time.time()
         wav = vocoder.inference(c)
-    rtf = (time.time() - start) / (len(wav) / fs)
+        t3 = time.time()
+    rtf = (t3 - start) / (len(wav) / fs)
     logger.info(f"RTF: {rtf}")
+    logger.info(f"Elapsed text2speech: {t2 - start}")
+    logger.info(f"Elapsed vocoder: {t3 - t2}")
     return wav.view(-1).cpu().numpy()

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -3,7 +3,7 @@ import torch
 import time
 from espnet_model_zoo.downloader import ModelDownloader
 from espnet2.bin.tts_inference import Text2Speech
-from functools import reduce
+from functools import reduce, lru_cache
 from os import environ
 from parallel_wavegan.utils import download_pretrained_model
 from parallel_wavegan.utils import load_model
@@ -14,6 +14,7 @@ logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+@lru_cache
 def tts(text, tag = "kan-bayashi/ljspeech_conformer_fastspeech2", vocoder_tag = "ljspeech_parallel_wavegan.v1"):
     d = ModelDownloader()
     device = environ["TORCH_DEVICE"]

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -20,16 +20,16 @@ d = ModelDownloader()
 device = environ["TORCH_DEVICE"]
 logger.info(f"Device: {device}")
 text2speech = Text2Speech(
-        **d.download_and_unpack(tag),
-        device=device,
-        threshold=0.5,
-        minlenratio=0.0,
-        maxlenratio=10.0,
-        use_att_constraint=False,
-        backward_window=1,
-        forward_window=3,
-        # Only for FastSpeech & FastSpeech2
-        speed_control_alpha=1.0,
+    **d.download_and_unpack(tag),
+    device=device,
+    threshold=0.5,
+    minlenratio=0.0,
+    maxlenratio=10.0,
+    use_att_constraint=False,
+    backward_window=1,
+    forward_window=3,
+    # Only for FastSpeech & FastSpeech2
+    speed_control_alpha=1.0,
 )
 text2speech.spc2wav = None
 vocoder = load_model(download_pretrained_model(vocoder_tag)).to(device).eval()


### PR DESCRIPTION
Use the `lru_cache` decorator from functools to resolve #62. To keep wall time down, a single model is spawned (similar to how other containers are working) on start and the `tts_segments` function is removed internally and replaced with calls to the cached `tts` function.


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
