### PR TITLE
Added schemas for chart models

### DIFF
--- a/preprocessors/chart-information.schema.json
+++ b/preprocessors/chart-information.schema.json
@@ -185,7 +185,7 @@
     "properties": {
         "type": {
             "description": "Type of chart: Line/Bar/Pie",
-            "enum": ["line", "bar", "pie"]
+            "enum": ["Line Chart", "Bar Chart", "Pie Chart"]
         },
         "dimensions": {
             "description": "Image dimensions in pixels (h, w)",


### PR DESCRIPTION
This PR is part of issue #68.

The schema files for the chart model have been added under schemas/preprocessors/
1. line-response.schema.json - json schema for line charts
2. bar-response.schema.json - json schema for bar charts
3. pie-response.schema.json - json schema for pie charts