### PR TITLE
Use Gunicorn for running semseg

### DIFF
--- a/preprocessors/semanticSeg/Dockerfile
+++ b/preprocessors/semanticSeg/Dockerfile
@@ -9,6 +9,7 @@ RUN pip3 install --upgrade pip
 RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y git
 RUN pip install -r /app/requirements.txt
+RUN pip install gunicorn
 
 COPY --from=schemas /schemas /app/schemas
 WORKDIR /app
@@ -19,4 +20,5 @@ RUN wget bach.cim.mcgill.ca/atp/models/semanticSegmentation/encoder_epoch_20.pth
 
 EXPOSE 5000
 ENV FLASK_APP=segment.py
-CMD [ "flask", "run", "--host=0.0.0.0" ]
+#CMD [ "flask", "run", "--host=0.0.0.0" ]
+CMD [ "gunicorn", "segment:app", "-b", "0.0.0.0:5000" ]

--- a/preprocessors/semanticSeg/segment.py
+++ b/preprocessors/semanticSeg/segment.py
@@ -224,4 +224,4 @@ def segment():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=False)


### PR DESCRIPTION
All this does is change semseg to use [gunicorn](https://gunicorn.org/) rather than plain Flask in debug mode. When run on Bach, RAM memory usage stays at about 1.75 GB and does not rise with repeated requests. Fixes #146.

Note that this is not meant for an actual merge, but is to show something.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
