### PR TITLE
Create two new types: segment offset for samples and for seconds

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -75,7 +75,7 @@
             },
             "required": [ "type_id", "confidence", "description", "data" ]
         },
-        "segmentOffset": {
+        "segmentOffsetSamples": {
             "description": "Data on the offset of an audio segment in the file and its duration. Both are reported in samples.",
             "type": "object",
             "properties": {

--- a/renderers/definitions.json
+++ b/renderers/definitions.json
@@ -4,6 +4,21 @@
     "title": "Renderer definitions",
     "description": "Common definitions used in renderers.",
     "definitions": {
+        "segmentOffsetSeconds": {
+        "description": "Data on the offset of an audio segment in the file and its duration. Both are reported in seconds.",
+            "type": "object",
+            "properties": {
+                "offset": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "duration": {
+                    "type": "number",
+                    "minimum": 0
+                }
+            },
+            "required": [ "offset", "duration" ]
+        },
         "remoteAudioFile": {
             "description": "HTTP(S) URL to an audio file.",
             "type": "string",

--- a/renderers/segmentaudio.schema.json
+++ b/renderers/segmentaudio.schema.json
@@ -10,7 +10,7 @@
             "type": "array",
             "items": {
                 "allOf": [
-                    { "$ref": "../definitions.json#/definitions/segmentOffset" },
+                    { "$ref": "./definitions.json#/definitions/segmentOffsetSeconds" },
                     {
                         "type": "object",
                         "properties": {

--- a/services/supercollider/tts-description.schema.json
+++ b/services/supercollider/tts-description.schema.json
@@ -9,11 +9,11 @@
             "description": "The locations of the introduction phrase and filler words in the TTS audio.",
             "type": "object",
             "properties": {
-                "intro": { "$ref": "../../definitions.json#/definitions/segmentOffset" },
+                "intro": { "$ref": "../../definitions.json#/definitions/segmentOffsetSamples" },
                 "joining": {
                     "description": "Joining words",
                     "type": "object",
-                    "additionalProperties": { "$ref": "../../definitions.json#/definitions/segmentOffset" }
+                    "additionalProperties": { "$ref": "../../definitions.json#/definitions/segmentOffsetSamples" }
                 }
             },
             "required": [ "intro" ]
@@ -39,7 +39,7 @@
                     {
                         "type": "object",
                         "properties": {
-                            "offset": { "$ref": "../../definitions.json#/definitions/segmentOffset" }
+                            "offset": { "$ref": "../../definitions.json#/definitions/segmentOffsetSamples" }
                         }
                     }
                 ]

--- a/services/supercollider/tts-segment.schema.json
+++ b/services/supercollider/tts-segment.schema.json
@@ -57,7 +57,7 @@
                         "type": "object",
                         "description": "TTS reading of segment name information.",
                         "properties": {
-                            "audio": { "$ref": "../../definitions.json#/definitions/segmentOffset" }
+                            "audio": { "$ref": "../../definitions.json#/definitions/segmentOffsetSamples" }
                         }
                     }
                 ]


### PR DESCRIPTION
Validates locally and fixes #188 when tested locally. Essentially split out into two types that are identical except one encodes offset info in samples (more convenient for SuperCollider) and another in seconds (more convenient for the browser).