### PR TITLE
Create simplehaptics.schema.json

### DIFF
--- a/renderers/simplehaptics.schema.json
+++ b/renderers/simplehaptics.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "ca.mcgill.a11y.image.renderer.SimpleHaptics",
+    "title": "Simple Haptics Renderer",
+    "type": "object",
+    "description": "Data for the haptic roundtrip testing ca.mcgill.a11y.image.renderer.SimpleHaptics. renderer sends the coordinate and centroid information ",
+    "properties": {
+        "image": {
+            "type": "string"
+        },
+        "data":{
+            "type":"array",
+            "items":{
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "text" : {
+                                "type": "string"
+                                },
+                                "centroids": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "number",
+                                        "minimum":0,
+                                        "maximum":1
+                                    },
+                                    "minItems": 2,
+                                    "maxItems": 2
+                                },
+                                "coords": {
+                                    "type": "array",
+                                    "items": { 
+                                        "type": "number", 
+                                        "minimum": 0, 
+                                        "maximum": 1 
+                                    }, 
+                                    "minItems": 4, 
+                                    "maxItems": 4 
+                                }
+                        },
+                        "required": [ "centroids", "coords"]
+                    }   
+                ]
+            } 
+        }
+    },
+    "required": [ "data"]
+}


### PR DESCRIPTION
This schema is for the roundtrip test of the haptics schema. The haptics renderings are validated against this schema.  This is for issue #110 

