### PR TITLE
Drop scene recognition until replaced

### DIFF
--- a/handlers/generic-tts-handler/src/server.ts
+++ b/handlers/generic-tts-handler/src/server.ts
@@ -119,7 +119,7 @@ app.post("/handler", async (req, res) => {
     } else if (secondClassifierData) {
         const category: string = secondClassifierData["category"];
         if (category === "indoor" || category === "outdoor") {
-            ttsIntro = `This picture of an ${category} scene contains`;
+            ttsIntro = `This ${category} picture contains`;
         } else {
             ttsIntro = "This picture contains";
         }

--- a/handlers/object-text-handler/src/server.ts
+++ b/handlers/object-text-handler/src/server.ts
@@ -100,7 +100,7 @@ app.post("/handler", async (req, res) => {
     } else if (secondClassifierData) {
         const key: string = secondClassifierData["category"];
         if (key === "indoor" || key === "outdoor") {
-            intro = `This picture of an ${key} scene contains`;
+            intro = `This ${key} picture contains`;
         } else {
             intro = "This picture contains";
         }


### PR DESCRIPTION
Hard drop scene recognition and instead look at second categoriser (this really needs a better name). If it's indoor/outdoor, announce it. Otherwise don't ("other" adds no info and "people" is redundant with the later object detection).

This is to address the more severe issues in #167. Note that scene recognition is not deleted from the source or from `docker-compose.yml` since that's a bigger decision.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
