### PR TITLE
Looser regex for URIs

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -28,7 +28,7 @@
         "data_schema": {
             "description": "A URL that resolves to the JSON schema for the data property.",
             "type": "string",
-            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
         },
         "metadata": {
             "description": "Metadata describing the handler that created a rendering.",
@@ -37,7 +37,7 @@
                 "homepage": {
                     "description": "The page for this handler, its package, the team that made it, etc.",
                     "type": "string",
-                    "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
+                    "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
                 },
                 "description": {
                     "description": "A brief description of the called handler.",

--- a/preprocessors/autour.schema.json
+++ b/preprocessors/autour.schema.json
@@ -9,7 +9,7 @@
             "type": "string",
             "title": "URL",
             "description": "The URL of the map",
-            "pattern": "^https?://.*"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
         },
         "lat": {
             "type": "number",
@@ -29,7 +29,7 @@
             "type": "string",
             "title": "API Request",
             "description": "The API request to be made to the map",
-            "pattern": "^https?://.*"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
         },
         "places": {
             "type": "array",

--- a/renderers/definitions.json
+++ b/renderers/definitions.json
@@ -22,7 +22,7 @@
         "remoteAudioFile": {
             "description": "HTTP(S) URL to an audio file.",
             "type": "string",
-            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
         },
         "localAudioFile": {
             "description": "Data URI of an encoded audio file.",

--- a/request.schema.json
+++ b/request.schema.json
@@ -46,7 +46,7 @@
         "URL": {
             "description": "URL of the page the request was generated from.",
             "type": "string",
-            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$"
+            "pattern": "^https?://(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,}\\.[a-z]{2,}\\b(\\S*)$"
         },
         "language": {
             "description": "Language requested by the user as ISO 639-1.",


### PR DESCRIPTION
This just allows more characters after the domain to match and removes
length limits on parts of the domain name. Technically this won't allow *everything* that's valid since it won't match against IRIs, but hopefully it should cover URIs. If this is not loose enough it may be necessary to just drop validation of URIs/IRIs.
Resolves #189 and resolves Shared-Reality-Lab/auditory-haptic-graphics-browser#93.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [ ] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
