### PR TITLE
Ensure gunicorn output captured at debug level

### DIFF
--- a/preprocessors/categoriser/Dockerfile
+++ b/preprocessors/categoriser/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE 5000
 ENV FLASK_APP=categoriser.py
 ENV TORCH_HOME=/app
 USER python
-CMD [ "gunicorn", "categoriser:app", "-b", "0.0.0.0:5000" ]
+CMD [ "gunicorn", "categoriser:app", "-b", "0.0.0.0:5000", "--capture-output", "--log-level=debug" ]

--- a/preprocessors/categoriser2/Dockerfile
+++ b/preprocessors/categoriser2/Dockerfile
@@ -18,4 +18,4 @@ COPY . /app
 EXPOSE 5000
 ENV FLASK_APP=azure_api.py
 USER python
-CMD [ "gunicorn", "azure_api:app", "-b", "0.0.0.0:5000" ]
+CMD [ "gunicorn", "azure_api:app", "-b", "0.0.0.0:5000", "--capture-output", "--log-level=debug" ]

--- a/preprocessors/chart-pipeline/boot.sh
+++ b/preprocessors/chart-pipeline/boot.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec gunicorn -b 0.0.0.0:5000 chart:app
+exec gunicorn -b 0.0.0.0:5000 chart:app --capture-output --log-level=debug

--- a/preprocessors/grouping/Dockerfile
+++ b/preprocessors/grouping/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 5000
 
 ENV FLASK_APP=grouping.py
 USER python
-CMD [ "gunicorn", "grouping:app", "-b", "0.0.0.0:5000" ]
+CMD [ "gunicorn", "grouping:app", "-b", "0.0.0.0:5000", "--capture-output", "--log-level=debug" ]

--- a/preprocessors/yolo/Dockerfile
+++ b/preprocessors/yolo/Dockerfile
@@ -21,4 +21,4 @@ EXPOSE 5000
 
 ENV FLASK_APP=detect.py
 USER python
-CMD [ "gunicorn", "detect:app", "-b", "0.0.0.0:5000" ]
+CMD [ "gunicorn", "detect:app", "-b", "0.0.0.0:5000", "--capture-output", "--log-level=debug" ]

--- a/services/espnet-tts/Dockerfile
+++ b/services/espnet-tts/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=schemas /schemas/services/tts/* ./
 ENV TORCH_DEVICE="cpu"
 EXPOSE 80
 
-CMD ["gunicorn", "app:app", "-b", "0.0.0.0:80"]
+CMD ["gunicorn", "app:app", "-b", "0.0.0.0:80", "--capture-output", "--log-level=debug"]


### PR DESCRIPTION
By default, gunicorn logging output doesn't go to stdout. This makes debugging issues much more difficult! This just makes sure out output is captured to stdout/stderr at the debug level, which is useful for us at this stage. This is already on Pegasus for debugging purposes and doesn't break anything.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
