### PR TITLE
Added new pytorch version

### DIFF
--- a/preprocessors/categoriser/Dockerfile
+++ b/preprocessors/categoriser/Dockerfile
@@ -1,5 +1,5 @@
 FROM schemas:latest AS schemas
-FROM pytorch/pytorch:1.8.1-cuda10.2-cudnn7-runtime
+FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
 
 COPY ./requirements.txt /app/requirements.txt
 

--- a/preprocessors/categoriser/requirements.txt
+++ b/preprocessors/categoriser/requirements.txt
@@ -4,6 +4,6 @@ numpy==1.20.1
 pillow==8.2.0
 jsonschema==3.2.0
 Werkzeug==0.16.0
-pytorch_lightning==1.4.4
+pytorch_lightning==1.5.0
 opencv-python== 4.5.1.48
 gunicorn==20.1.0

--- a/preprocessors/semanticSeg/Dockerfile
+++ b/preprocessors/semanticSeg/Dockerfile
@@ -1,5 +1,5 @@
 FROM schemas:latest AS schemas
-FROM pytorch/pytorch:1.8.1-cuda10.2-cudnn7-runtime
+FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
 
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-opencv wget git && rm -rf /var/lib/apt/lists/*

--- a/preprocessors/semanticSeg/requirements.txt
+++ b/preprocessors/semanticSeg/requirements.txt
@@ -2,9 +2,9 @@ flask==1.1.2
 flask_api==2.0.0
 numpy==1.20.1
 pillow==8.2.0
-requests==2.25.1
-torch==1.8.1
-torchvision==0.9.1
+requests==2.26.0
+torch==1.10.0
+torchvision==0.11.1
 jsonschema==3.2.0
 Werkzeug==0.16.0
 scipy==1.7.0


### PR DESCRIPTION
This PR is wrt to issue 242. The 2 models whose versions have been changed are 
```
1. First Categoriser
2. Semantic Segmentation
```

The version for both of them has been changed to 1.10 for PyTorch and the CUDA version is 11.3. The testing of the model has been done on pegasus. The following testing methodology has been followed for testing on pegasus:

1. Run `docker-compose up --build ` inside the folder
2. `docker ps -a` to get the orchestrator container number
3. get the IP address of the orchestrator and pass the json as a curl request.

The json used for testing can be found at path  `/home/rakut/test_jsons/image3.json`

Note: The object detection model has not been added to this PR because of the reasons mentioned in Issue [242](https://github.com/Shared-Reality-Lab/auditory-haptic-graphics-server/issues/242)