### PR TITLE
Commented out GPU specifications for Object Detection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,12 +69,12 @@ services:
         labels:
             ca.mcgill.a11y.image.preprocessor: 3
             ca.mcgill.a11y.image.port: 5000
-        deploy:
-            resources:
-                reservations:
-                    devices:
-                    - driver: nvidia
-                      capabilities: ["gpu", "utility", "compute"]
+        # deploy:
+        #     resources:
+        #         reservations:
+        #             devices:
+        #             - driver: nvidia
+        #               capabilities: ["gpu", "utility", "compute"]
     first-categoriser:
         build:
             context: ./preprocessors/categoriser


### PR DESCRIPTION
This PR is wrt issue [250](https://github.com/Shared-Reality-Lab/auditory-haptic-graphics-server/issues/250). The GPU section in docker-compose has been commented according to the discussion mentioned in the issue.

The code has been tested on pegasus using the json available at the path `/home/rakut/test/image3.json`