### PR TITLE
Add spatialized ping for single objects

### DIFF
--- a/services/supercollider-images/supercollider-service/generic.scd
+++ b/services/supercollider-images/supercollider-service/generic.scd
@@ -173,6 +173,18 @@ renderGeneric = { |json, ttsData, outPath, addr|
                         \gain, 0.5 * volume.dbamp
                     ]
                 ]);
+                score.add([
+                    (timing + dur),
+                    [\s_new, (\pingHOA++order.asSymbol).asSymbol, -1, 2, 1001,
+                        \gain, 0.8 * volume.dbamp,
+                        \room, 0.6,
+                        \damp, 0.5,
+                        \mix, 0.3,
+                        \freq, item.at("centroid").at(1).asFloat.linlin(0.0, 1.0, 2000, 1000),
+                        \resonz, 0.01,
+                        \theta, theta,
+                        \phi, phi]
+                ]);
             },
             {
                 "No centroid on item!".postln;
@@ -182,7 +194,7 @@ renderGeneric = { |json, ttsData, outPath, addr|
                 ]);
             }
         );
-        timing = timing + dur;
+        timing = timing + dur + 0.5; // 0.5 for ping
     });
 
     // Add one last noop msg w/ half second pause


### PR DESCRIPTION
For the object rendering, include a spatialized ping after singleton objects. Before, the name would just be said with spatialization. This fixes #219. This has been tested on Unicorn with example image 2.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
