### PR TITLE
Changed download links for preprocessors

### DIFF
--- a/preprocessors/semanticSeg/Dockerfile
+++ b/preprocessors/semanticSeg/Dockerfile
@@ -18,8 +18,8 @@ RUN pip install -r /app/requirements.txt
 COPY --from=schemas /schemas /app/schemas
 COPY . /app
 
-RUN wget bach.cim.mcgill.ca/atp/models/semanticSegmentation/decoder_epoch_20.pth
-RUN wget bach.cim.mcgill.ca/atp/models/semanticSegmentation/encoder_epoch_20.pth
+RUN wget https://image.a11y.mcgill.ca/models/semanticSegmentation/decoder_epoch_20.pth
+RUN wget https://image.a11y.mcgill.ca/models/semanticSegmentation/encoder_epoch_20.pth
 
 EXPOSE 5000
 ENV FLASK_APP=segment.py


### PR DESCRIPTION
This PR is wrt to [issue 265](https://github.com/Shared-Reality-Lab/IMAGE-server/issues/265). In order to close issue 265 two preprocessors need to be modified namely
```
1. Object Detection
2. Semantic Segmentation
```
In this PR, only semantic segmentation has been modified. The code for object detection has been modified in [PR 268](https://github.com/Shared-Reality-Lab/IMAGE-server/pull/268). Since 2 PR's are resolving issue 265, I am not linking any issue to this PR.

@jeffbl @jaydeepsingh25 Due to above mentioned reasons, I haven't linked any issue to this PR. I will close the issue manually once both PR are aproved.

