### PR TITLE
Set NRT server verbosity to -1 (error only)

### DIFF
--- a/services/supercollider-images/supercollider-service/charts.scd
+++ b/services/supercollider-images/supercollider-service/charts.scd
@@ -74,7 +74,7 @@ pieChart = { |json, outPath, addr|
         sampleRate: 48000,
         headerFormat: "WAV",
         sampleFormat: "int16",
-        options: ServerOptions.new.numOutputBusChannels_(2),
+        options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for written file
             if(File.exists(outPath),

--- a/services/supercollider-images/supercollider-service/example.scd
+++ b/services/supercollider-images/supercollider-service/example.scd
@@ -85,7 +85,7 @@ score.recordNRT(
     sampleRate: 48000,
 	headerFormat: "WAV",
 	sampleFormat: "int16",
-    options: ServerOptions.new.numOutputBusChannels_(2),
+    options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
     action: { addr.sendMsg(\status); }
 );
 

--- a/services/supercollider-images/supercollider-service/generic.scd
+++ b/services/supercollider-images/supercollider-service/generic.scd
@@ -210,7 +210,7 @@ renderGeneric = { |json, ttsData, outPath, addr|
         sampleRate: 48000,
         headerFormat: "WAV",
         sampleFormat: "int16",
-        options: ServerOptions.new.numOutputBusChannels_(2),
+        options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for successful write (file exists)
             if(File.exists(outPath),

--- a/services/supercollider-images/supercollider-service/segmentation.scd
+++ b/services/supercollider-images/supercollider-service/segmentation.scd
@@ -115,7 +115,7 @@ renderSegments = { |json, ttsData, outPath, addr|
         sampleRate: 48000,
         headerFormat: "WAV",
         sampleFormat: "int16",
-        options: ServerOptions.new.numOutputBusChannels_(2),
+        options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for written file
             if(File.exists(outPath),


### PR DESCRIPTION
This should hide the many, many, many nextOSCPacket messages. This has been tested locally and hides the NRT server messages only. Debugging `postln` statements still appear in logs.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
