### PR TITLE
Request port 0 when using OSC

### DIFF
--- a/handlers/generic-tts-handler/src/server.ts
+++ b/handlers/generic-tts-handler/src/server.ts
@@ -246,7 +246,8 @@ app.post("/handler", async (req, res) => {
         const oscPort = new osc.UDPPort({
             "remoteAddress": "supercollider",
             "remotePort": scPort,
-            "localAddress": "0.0.0.0"
+            "localAddress": "0.0.0.0",
+            "localPort": 0  // This will request a free port
         });
         return Promise.race<string>([
             new Promise<string>((resolve, reject) => {

--- a/handlers/hello-tts-handler/src/server.ts
+++ b/handlers/hello-tts-handler/src/server.ts
@@ -105,7 +105,8 @@ app.post("/handler", async (req, res) => {
                     const oscPort = new osc.UDPPort({
                         "remoteAddress": "supercollider",
                         "remotePort": scPort,
-                        "localAddress": "0.0.0.0"
+                        "localAddress": "0.0.0.0",
+                        "localPort": 0  // This will request a free port
                     });
                     console.log("Sending message...");
                     return new Promise<string>((resolve, reject) => {

--- a/handlers/pie-chart-handler/src/server.ts
+++ b/handlers/pie-chart-handler/src/server.ts
@@ -100,7 +100,8 @@ app.post("/handler", async (req, res) => {
     const oscPort = new osc.UDPPort({
         "remoteAddress": "supercollider",
         "remotePort": scPort,
-        "localAddress": "0.0.0.0"
+        "localAddress": "0.0.0.0",
+        "localPort": 0  // This will request a free port
     });
     try {
         await Promise.race<string>([

--- a/handlers/segment-handler/src/server.ts
+++ b/handlers/segment-handler/src/server.ts
@@ -176,7 +176,8 @@ app.post("/handler", async (req, res) => {
         const oscPort = new osc.UDPPort({
             "remoteAddress": "supercollider",
             "remotePort": scPort,
-            "localAddress": "0.0.0.0"
+            "localAddress": "0.0.0.0",
+            "localPort": 0  // This will request a free port
         });
 
         // Send response and receive reply or timeout


### PR DESCRIPTION
This should be resolved into a free port by the system. This resolves #293. Since testing with a race condition is difficult, I just manually opened a REPL with the osc.js library and opened two ports requesting port 0. Both successfully opened. In other cases (e.g., the default) this would result in an error.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
