### PR TITLE
Changed Pillow and numpy versions

### DIFF
--- a/preprocessors/scene/requirements.txt
+++ b/preprocessors/scene/requirements.txt
@@ -1,8 +1,8 @@
 flask==1.1.2
 flask_api==2.0.0
-numpy==1.20.1
+numpy==1.21.0
 opencv-python== 4.5.1.48
-pillow==8.2.0
+pillow==9.0.0
 requests==2.25.1
 torch==1.8.1
 torchvision==0.9.1

--- a/preprocessors/semanticSeg/requirements.txt
+++ b/preprocessors/semanticSeg/requirements.txt
@@ -1,7 +1,7 @@
 flask==1.1.2
 flask_api==2.0.0
-numpy==1.20.1
-pillow==8.2.0
+numpy==1.21.0
+pillow==9.0.0
 requests==2.26.0
 torch==1.10.0
 torchvision==0.11.1

--- a/preprocessors/sorting/requirements.txt
+++ b/preprocessors/sorting/requirements.txt
@@ -1,7 +1,7 @@
 flask==1.1.2
 flask_api==2.0.0
 numpy==1.20.1
-pillow==8.2.0
+pillow==9.0.0
 jsonschema==3.2.0
 Werkzeug==0.16.0
 gunicorn==20.1.0

--- a/preprocessors/sorting/requirements.txt
+++ b/preprocessors/sorting/requirements.txt
@@ -1,6 +1,6 @@
 flask==1.1.2
 flask_api==2.0.0
-numpy==1.20.1
+numpy==1.21.0
 pillow==9.0.0
 jsonschema==3.2.0
 Werkzeug==0.16.0


### PR DESCRIPTION
The numpy and Pillow verions have been updated to latest versions in light of the security breaches highlighted in their previous versions. The new versions have been tested on json present in `/home/rakut/test_jsons` on unicorn