### PR TITLE
Downscaling large images

### DIFF
--- a/preprocessors/semanticSeg/segment.py
+++ b/preprocessors/semanticSeg/segment.py
@@ -122,8 +122,9 @@ def run_segmentation(url,
     image = np.asarray(bytearray(binary), dtype="uint8")
     pil_image = cv2.imdecode(image, cv2.IMREAD_COLOR)
     height, width, channels = pil_image.shape
-    if(height>1500 or width >1500):
-        pil_image = cv2.resize(pil_image, (1500,1500), interpolation = cv2.INTER_AREA)
+    if(height > 1500 or width > 1500):
+        pil_image = cv2.resize(pil_image, (1500, 1500),
+                               interpolation=cv2.INTER_AREA)
     img = pil_image
     img_original = numpy.array(img)
     img_data = pil_to_tensor(img)

--- a/preprocessors/semanticSeg/segment.py
+++ b/preprocessors/semanticSeg/segment.py
@@ -122,6 +122,8 @@ def run_segmentation(url,
     image = np.asarray(bytearray(binary), dtype="uint8")
     pil_image = cv2.imdecode(image, cv2.IMREAD_COLOR)
     height, width, channels = pil_image.shape
+    if(height>1500 or width >1500):
+        pil_image = cv2.resize(pil_image, (1500,1500), interpolation = cv2.INTER_AREA)
     img = pil_image
     img_original = numpy.array(img)
     img_data = pil_to_tensor(img)


### PR DESCRIPTION
This PR is wrt to issue 290. The code has been tested on the same image mentioned in 290. The code has been tested on unicorn and downscaling to `(1500,1500)` prevents OOM of image. I have only kept this condition for larger images, that is images greater than `(1500,1500)` will be downscaled to the mentioned size. The smaller images would not be changed in size.