### PR TITLE
New segment format for photo-audio, supercollider responder

### DIFF
--- a/handlers/photo-audio-handler/src/utils.ts
+++ b/handlers/photo-audio-handler/src/utils.ts
@@ -70,9 +70,9 @@ export function generateSemSeg(semSeg: { "segments": Record<string, unknown>[] }
     data.push({"value": "contains the following outlines of regions:", "type": "text"});
     data.push(...segments.map(segment => {
         const newSeg = segment;
-        newSeg["value"] = (newSeg["nameOfSegment"] as string) + ",";
+        newSeg["value"] = (newSeg["name"] as string) + ",";
         newSeg["type"] = "segment";
-        newSeg["label"] = newSeg["nameOfSegment"] as string;
+        newSeg["label"] = newSeg["name"] as string;
         return newSeg as TTSSegment;
     }));
     data[data.length-1]["value"] = data[data.length - 1]["value"].replace(",", ".");

--- a/services/supercollider-images/supercollider-service/IMAGE/IMAGE.sc
+++ b/services/supercollider-images/supercollider-service/IMAGE/IMAGE.sc
@@ -233,10 +233,13 @@ IMAGE {
             // Play klank for segmentations
             SynthDef((\playKlankNoise4SegmentHOA++(i+1)).asSymbol, { |midinote = 60,
                                                                       theta = 0.0pi, phi = 0.0pi, radius = 2.5,
-                                                                      out = 2, gain = 0, lag = 0.1|
-            var sig, encoded;
-                sig = Klank.ar(`[{|i|  (i+1) + 0.01.rand2 }!18, {|i| 1/(i+1) }!18, {|i| 2/(i+1) }!18], BrownNoise.ar(0.001) + Dust.ar(50, 0.5) , midinote.midicps  ) * AmpComp.kr(midinote.midicps, 300);
-                encoded = HoaEncodeDirection.ar(sig * gain.lag(lag), theta.lag(lag),
+                                                                      out = 2, gain = 0, lag = 0.1, release=0.5, gate=1|
+            var sig, encoded, env, envGen;
+                env = Env.asr(releaseTime: release);
+                envGen = EnvGen.ar(env, gate);
+                sig = Klank.ar(`[{|i|  (i+1) + 0.01.rand2 }!18, {|i| 1/(i+1) }!18, {|i| 2/(i+1) }!18], BrownNoise.ar(0.001) + Dust.ar(50, 0.5) , midinote.midicps  ) * envGen * AmpComp.kr(midinote.midicps, 300);
+                DetectSilence.ar(sig, doneAction: Done.freeSelf);
+                encoded = HoaEncodeDirection.ar(sig* gain.lag(lag), theta.lag(lag),
                                                      phi.lag(lag),
                                                      radius.lag(lag),
                                                      order.asInteger);

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -120,8 +120,8 @@ renderPhoto = { |json, ttsData, outPath, addr|
                 segmentInfo = segmentInfo.add(timing - initialTiming);
             },
             \segment, {
-                var duration = (audio.at("duration").asInteger / ttsData.sampleRate), coord = item.at("coord"), area = item.at("area").asFloat, maxTime=25, totalTime=maxTime*area, pingDur=0.01, midinote, initialTiming=timing;
-                // TTS and then segment outline
+                var contours = item.at("contours"), duration = (audio.at("duration").asInteger / ttsData.sampleRate), initialTiming=timing;
+                // TTS and then segment outlines
                 "segment".postln;
                 score.add([
                     timing,
@@ -129,25 +129,31 @@ renderPhoto = { |json, ttsData, outPath, addr|
                 ]);
                 timing = timing + duration;
 
-                coord = coord.resamp0((totalTime / pingDur).asInteger);
-                midinote = item.at("centroid").at(1).asFloat.linlin(0.0, 1.0, 57, 45).round;
-                score.add([
-                    timing,
-                    [\s_new, (\playKlankNoise4SegmentHOA++order.asSymbol).asSymbol, 1003, 2, 1001, \midinote, midinote, \lag, pingDur, \gain, baseGain * -20.dbamp]
-                ]);
-                coord.do({ |point|
-                    var x, y, theta, phi;
-                    x = point.at(0).asFloat;
-                    y = point.at(1).asFloat;
-                    # theta, phi = IMAGE.mapCoords(x, y);
+                contours.do({ |contour, i|
+                    var coord = contour.at("coordinates"), area = contour.at("area").asFloat, centroid = contour.at("centroid"), maxTime=25, pingDur=0.01, contourTime = area*maxTime, midinote;
+
+                    coord = coord.resamp0((contourTime / pingDur).asInteger);
+                    midinote = item.at("centroid").at(1).asFloat.linlin(0.0, 1.0, 57, 45).round;
                     score.add([
                         timing,
-                        [\n_set, 1003, \theta, theta, \phi, phi]
+                        [\s_new, (\playKlankNoise4SegmentHOA++order.asSymbol).asSymbol, 1003, 2, 1001, \midinote, midinote, \lag, pingDur, \gain, baseGain * -20.dbamp]
                     ]);
-                    timing = timing + pingDur;
+                    coord.do({ |point|
+                        var x, y, theta, phi;
+                        x = point.at(0).asFloat;
+                        y = point.at(1).asFloat;
+                        # theta, phi = IMAGE.mapCoords(x, y);
+                        score.add([
+                            timing,
+                            [\n_set, 1003, \theta, theta, \phi, phi]
+                        ]);
+                        timing = timing + pingDur;
+                    });
+                    score.add([timing, [\n_set, 1003, \gate, 0.0]]);
+                    timing = timing + 0.5; // Pause between contours
+                    score.add([timing, [\n_free, 1003]]);
                 });
-                score.add([timing, [\n_set, 1003, \gain, 0.0]]);
-                score.add([timing, [\n_free, 1003]]);
+
 
                 if(item.at("label").notNil,
                     {


### PR DESCRIPTION
This addresses the remaining two points of #221 for the photo-audio pipeline. Note that this does NOT fix the deprecated segment-handler or its responder. For those that piggyback on the photo-audio pipeline in supercollider, it should just be necessary to rename one or two keys (e.g., `nameOfSegment` to `name`). This probably only impacts @sriGanna and @rayanisran. Resolves #221. Local pipeline from handler to TTS to supercollider and back tested locally using example 2 from the demo page.

This also updates the schemas submodule to latest HEAD in response to #281 being merged.

---

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
