### PR TITLE
Handle absent semseg data without crashing, exit on schema mismatch

### DIFF
--- a/handlers/photo-audio-handler/src/server.ts
+++ b/handlers/photo-audio-handler/src/server.ts
@@ -50,6 +50,7 @@ app.post("/handler", async (req, res) => {
     if (!ajv.validate("https://image.a11y.mcgill.ca/request.schema.json", req.body)) {
         console.warn("Request did not pass the schema!");
         res.status(400).json(ajv.errors);
+        return;
     }
 
     const renderings = [];
@@ -62,13 +63,13 @@ app.post("/handler", async (req, res) => {
     const objGroup = preprocessors["ca.mcgill.a11y.image.preprocessor.grouping"];
 
     // Ignore secondCat since it isn't useful on its own
-    if (!semseg && !objDet && !objGroup) {
+    if (!(semseg && semseg?.segments) && !(objDet && objDet?.objects) && !objGroup) {
         console.debug("No usable preprocessor data! Can't render.");
         const response = utils.generateEmptyResponse(req.body["request_uuid"]);
         res.json(response);
         return;
     }
-    else if (semseg["segments"].length === 0 && objDet["objects"].length === 0) {
+    else if (semseg?.segments.length === 0 && objDet?.objects.length === 0) {
         console.debug("No segments or objects detected! Can't render.");
         const response = utils.generateEmptyResponse(req.body["request_uuid"]);
         res.json(response);


### PR DESCRIPTION
Minor issues with photo-audio-handler when all preprocessors don't run right. Fixes an error when the semantic segmentation doesn't exist and another issue where the handler attempts to continue even after the request schema didn't match. Tested locally using the relevant preprocessors. No additional CI needed.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
