### PR TITLE
Bump parallel_wavegan version, download on build

### DIFF
--- a/services/espnet-tts/Dockerfile
+++ b/services/espnet-tts/Dockerfile
@@ -3,6 +3,7 @@ FROM pytorch/pytorch:1.10.0-cuda11.3-cudnn8-runtime
 RUN apt-get update && apt-get install -y libsndfile1 build-essential && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /run/tts
+RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 RUN adduser --disabled-password python
 RUN chown python:python .
 USER python
@@ -14,6 +15,9 @@ RUN pip install -r requirements.txt
 
 COPY /services/espnet-tts/src/predownload.py .
 RUN python predownload.py
+RUN mkdir -p /home/python/.cache/parallel_wavegan/ljspeech_full_band_melgan.v2
+RUN wget https://image.a11y.mcgill.ca/models/espnet/train_nodev_ljspeech_full_band_melgan.v2.tar.gz -O /home/python/.cache/parallel_wavegan/ljspeech_full_band_melgan.v2.tar.gz
+RUN tar xzvf /home/python/.cache/parallel_wavegan/ljspeech_full_band_melgan.v2.tar.gz -C /home/python/.cache/parallel_wavegan/ljspeech_full_band_melgan.v2/
 
 COPY /services/espnet-tts/src/* ./
 COPY /schemas/services/tts/* ./

--- a/services/espnet-tts/requirements.txt
+++ b/services/espnet-tts/requirements.txt
@@ -3,4 +3,4 @@ espnet_model_zoo==0.1.7
 Flask==2.0.2
 gunicorn==20.1.0
 jsonschema==4.4.0
-parallel_wavegan==0.4.8
+parallel_wavegan==0.5.4

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -26,8 +26,8 @@ from parallel_wavegan.utils import load_model
 
 fs = 22050
 tag = "kan-bayashi/ljspeech_conformer_fastspeech2"
-vocoder_tag = "ljspeech_parallel_wavegan.v3"
-# vocoder_tag = "ljspeech_full_band_melgan.v2"
+# vocoder_tag = "ljspeech_parallel_wavegan.v3"
+vocoder_tag = "ljspeech_full_band_melgan.v2"
 
 logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/services/espnet-tts/src/espnet_util.py
+++ b/services/espnet-tts/src/espnet_util.py
@@ -26,8 +26,8 @@ from parallel_wavegan.utils import load_model
 
 fs = 22050
 tag = "kan-bayashi/ljspeech_conformer_fastspeech2"
-# vocoder_tag = "ljspeech_parallel_wavegan.v3"
-vocoder_tag = "ljspeech_full_band_melgan.v2"
+vocoder_tag = "ljspeech_parallel_wavegan.v3"
+# vocoder_tag = "ljspeech_full_band_melgan.v2"
 
 logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/services/espnet-tts/src/predownload.py
+++ b/services/espnet-tts/src/predownload.py
@@ -15,7 +15,7 @@
 # <https://github.com/Shared-Reality-Lab/IMAGE-server/LICENSE>.
 
 from espnet_model_zoo.downloader import ModelDownloader
-from parallel_wavegan.utils import download_pretrained_model
+# from parallel_wavegan.utils import download_pretrained_model
 
 d = ModelDownloader()
 d.download_and_unpack("kan-bayashi/ljspeech_conformer_fastspeech2")

--- a/services/espnet-tts/src/predownload.py
+++ b/services/espnet-tts/src/predownload.py
@@ -19,4 +19,4 @@ from parallel_wavegan.utils import download_pretrained_model
 
 d = ModelDownloader()
 d.download_and_unpack("kan-bayashi/ljspeech_conformer_fastspeech2")
-download_pretrained_model("ljspeech_parallel_wavegan.v1")
+download_pretrained_model("ljspeech_full_band_melgan.v2")

--- a/services/espnet-tts/src/predownload.py
+++ b/services/espnet-tts/src/predownload.py
@@ -19,4 +19,4 @@ from parallel_wavegan.utils import download_pretrained_model
 
 d = ModelDownloader()
 d.download_and_unpack("kan-bayashi/ljspeech_conformer_fastspeech2")
-download_pretrained_model("ljspeech_full_band_melgan.v2")
+download_pretrained_model("ljspeech_parallel_wavegan.v3")

--- a/services/espnet-tts/src/predownload.py
+++ b/services/espnet-tts/src/predownload.py
@@ -19,4 +19,4 @@ from parallel_wavegan.utils import download_pretrained_model
 
 d = ModelDownloader()
 d.download_and_unpack("kan-bayashi/ljspeech_conformer_fastspeech2")
-download_pretrained_model("ljspeech_parallel_wavegan.v3")
+# download_pretrained_model("ljspeech_parallel_wavegan.v3")


### PR DESCRIPTION
Downloading on run can lead to #353 when we hit Google's rate limiting.
So we are setting melgan to be the default downloaded on build.

Update: after continuing to run into rate limiting, we are storing a copy locally. This is downloaded and extracted at build. Tested the container itself locally with these changes. It starts properly and responds to requests as expected. Fixes #353.

Fun tip! You can get the WAV file for a request from the command line using the following: 
`curl -H "Content-Type: application/json" -d '{"segments":["Hello, world!"]}' http://$TTS_IP_ADDR/service/tts/segments | jq -r '.audio' - | awk -F, '{ print $2 }' | base64 -d - > test.wav`

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable