### PR TITLE
Fitler OSM way segments for POI rendering.

### DIFF
--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -105,7 +105,7 @@ app.post("/handler", async (req, res) => {
     // Form TTS segments
     const ttsIntro = "From due north moving clockwise, there are the following";
     const segments = [ttsIntro];
-    for (const place of autourData["places"]) {
+    for (const place of places) {
         segments.push(place["title"]);
     }
 
@@ -131,7 +131,8 @@ app.post("/handler", async (req, res) => {
 
     const durations = (ttsResponse as Record<string, unknown>)["durations"] as number[];
     let runningOffset = 0;
-    const scData = autourData;
+    const scData = JSON.parse(JSON.stringify(autourData));
+    scData["places"] = places;
     scData["ttsFileName"] = "";
 
     let durIdx = 0;

--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -92,7 +92,7 @@ app.post("/handler", async (req, res) => {
 
     // Sort and filter POIs
     // Do this before since TTS is time consuming
-    const places = autourData["places"].filter(p => !filterCategories.contains(p));
+    const places = autourData["places"].filter((p: { "cat": number }) => !filterCategories.includes(p["cat"]));
     const source = new LatLon(autourData["lat"], autourData["lon"]);
     for (const place of places) {
         const dest = new LatLon(place["ll"][0], place["ll"][1]);

--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -24,6 +24,7 @@ const app = express();
 const port = 80;
 const scPort = 57120;
 const filePrefix = "/tmp/sc-store/autour-handler-";
+const filterCategories = [89]; // Remove OSM way segments
 
 app.use(express.json({limit: process.env.MAX_BODY}));
 
@@ -91,7 +92,7 @@ app.post("/handler", async (req, res) => {
 
     // Sort and filter POIs
     // Do this before since TTS is time consuming
-    const places = autourData["places"];
+    const places = autourData["places"].filter(p => !filterCategories.contains(p));
     const source = new LatLon(autourData["lat"], autourData["lon"]);
     for (const place of places) {
         const dest = new LatLon(place["ll"][0], place["ll"][1]);

--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -108,7 +108,7 @@ autourStyle = { |json, ttsData, outPath, addr|
         sampleRate: 48000,
         headerFormat: "WAV",
         sampleFormat: "int16",
-        options: ServerOptions.new.numOutputBusChannels_(2),
+        options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for successful write (file exists)
             if(File.exists(outPath),


### PR DESCRIPTION
Resolve #355 by adding filtering functionality. This will check for category numbers to filter out (currently only 89 - OSM way segment). Tested on Unicorn with space needle example. Filters out paths and returns correct number of good objects. Also fix bugs related to JS reference/deep copying.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
