### PR TITLE
Prevent memory issues in TTS

### DIFF
--- a/services/espnet-tts/src/app.py
+++ b/services/espnet-tts/src/app.py
@@ -24,6 +24,7 @@ from espnet_util import tts, fs
 from flask import Flask, Response, request
 from io import BytesIO
 from jsonschema import validate
+from torch.cuda import empty_cache
 from werkzeug.wsgi import FileWrapper
 
 logging.basicConfig(format="%(asctime)s %(message)s")
@@ -61,6 +62,8 @@ def perform_tts():
         return {
             "error": "An error occurred while performing text-to-speech"
         }, 500
+    finally:
+        empty_cache()
 
 
 @app.route("/service/tts/segments", methods=["POST"])
@@ -107,3 +110,5 @@ def segment_tts():
         return {
             "error": "An error occurred while performing text-to-speech"
         }, 500
+    finally:
+        empty_cache()


### PR DESCRIPTION
On Pegasus, TTS was making extremely large requests (10 GB GPU memory), failing to allocate, and then holding on to large amounts of memory. It's unclear what request was made that lead to the attempted allocation - no other requests of the same type get close - but we can address holding onto memory for now. This will call empty_cache at the end of every request on success or failure and ideally prevent catastrophic results.

Tested on Unicorn with changes. Responds and generates TTS audio correctly.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
