### PR TITLE
Add dependencies by handlers on services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
         image: ghcr.io/shared-reality-lab/image-handler-autour:unstable
         env_file:
             - ./config/express-common.env
+        depends_on:
+            - supercollider
+            - espnet-tts
         labels:
             ca.mcgill.a11y.image.handler: enable
         volumes:
@@ -101,6 +104,9 @@ services:
         image: ghcr.io/shared-reality-lab/image-handler-photo-audio:unstable
         env_file:
             - ./config/express-common.env
+        depends_on:
+            - supercollider
+            - espnet-tts
         labels:
             ca.mcgill.a11y.image.handler: enable
         volumes:
@@ -115,6 +121,9 @@ services:
         image: ghcr.io/shared-reality-lab/image-handler-photo-audio-haptics:unstable
         env_file:
             - ./config/express-common.env
+        depends_on:
+            - supercollider
+            - espnet-tts
         labels:
             ca.mcgill.a11y.image.handler: enable
         volumes:


### PR DESCRIPTION
Add `depends_on` key to handlers so their services start. They'll often fail otherwise in ways that preprocessors won't. Resolves #280. Everything starts properly as tested on Unicorn.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
