### PR TITLE
Deprecate confidence in renderings

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -56,7 +56,7 @@
             "properties": {
                 "type_id": { "$ref": "#/definitions/renderer" },
                 "confidence": {
-                    "description": "Estimated percent confidence in the correctness of the rendering.",
+                    "description": "DEPRECATED: Estimated percent confidence in the correctness of the rendering.",
                     "type": "number",
                     "minimum": 0,
                     "maximum": 100
@@ -73,7 +73,7 @@
                     "type": "object"
                 }
             },
-            "required": [ "type_id", "confidence", "description", "data" ]
+            "required": [ "type_id", "description", "data" ]
         },
         "segmentOffsetSamples": {
             "description": "Data on the offset of an audio segment in the file and its duration. Both are reported in samples.",

--- a/definitions.json
+++ b/definitions.json
@@ -56,7 +56,7 @@
             "properties": {
                 "type_id": { "$ref": "#/definitions/renderer" },
                 "confidence": {
-                    "description": "DEPRECATED: Estimated percent confidence in the correctness of the rendering.",
+                    "description": "DEPRECATED (but reserved for future use): Estimated percent confidence in the correctness of the rendering.",
                     "type": "number",
                     "minimum": 0,
                     "maximum": 100


### PR DESCRIPTION
So far, we haven't been able to meaningfully create a confidence for an entire rendering. In case we do it remains in the schema (plus for backwards compatibility), but otherwise we mark it as deprecated and do not require it. Resolves #203. Confidence may continue as a per-preprocessor report.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
