### PR TITLE
Object size sonification tweaks

### DIFF
--- a/handlers/photo-audio-handler/src/server.ts
+++ b/handlers/photo-audio-handler/src/server.ts
@@ -70,7 +70,10 @@ app.post("/handler", async (req, res) => {
         res.json(response);
         return;
     }
-    else if (semseg?.segments.length === 0 && objDet?.objects.length === 0) {
+    // Filter objects
+    utils.filterObjectsBySize(objDet, objGroup);
+
+    if (semseg?.segments.length === 0 && objDet?.objects.length === 0) {
         console.debug("No segments or objects detected! Can't render.");
         const response = utils.generateEmptyResponse(req.body["request_uuid"]);
         res.json(response);

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -131,7 +131,7 @@ renderPhoto = { |json, ttsData, outPath, addr|
                 timing = timing + duration;
 
                 contours.do({ |contour, i|
-                    var coord = contour.at("coordinates"), area = contour.at("area").asFloat, centroid = contour.at("centroid"), maxTime=25, pingDur=0.01, contourTime = area*maxTime, midinote;
+                    var coord = contour.at("coordinates"), area = contour.at("area").asFloat, centroid = contour.at("centroid"), maxTime=15, pingDur=0.01, contourTime = area*maxTime, midinote;
 
                     coord = coord.resamp0((contourTime / pingDur).asInteger);
                     midinote = item.at("centroid").at(1).asFloat.linlin(0.0, 1.0, 57, 45).round;

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -89,7 +89,8 @@ renderPhoto = { |json, ttsData, outPath, addr|
                                 { start = lastIndex + minDiff; totalDur = totalDur + minDiff; }
                             );
                             lastIndex = start;
-                            volume = point.at("area").asFloat.linlin(0.01, 0.25, -5, 0);
+                            // Attempt to map onto curve of observed object sizes
+                            volume = -15 * (point.at("area").asFloat * -130).exp;
                             score.add([
                                 start,
                                 [\s_new, (\pingHOA++order.asSymbol).asSymbol, -1, 2, 1001,

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -89,7 +89,7 @@ renderPhoto = { |json, ttsData, outPath, addr|
                                 { start = lastIndex + minDiff; totalDur = totalDur + minDiff; }
                             );
                             lastIndex = start;
-                            volume = point.at("area").asFloat.linlin(0, 0.25, -5, 0);
+                            volume = point.at("area").asFloat.linlin(0.01, 0.25, -5, 0);
                             score.add([
                                 start,
                                 [\s_new, (\pingHOA++order.asSymbol).asSymbol, -1, 2, 1001,


### PR DESCRIPTION
This works to resolve #300 in two ways:

- Change scaling to focus more on the range of sizes where objects are likely to be (this is actually heavily around 1% of the total image or less).
- Filter out groups and lone objects less than 0.05% of the image. This filters the horse example and seems to be a safe threshold for objects that are unlikely to be significant. If there's a compelling counterexample, please let me know.

This has been tested locally with various test images. The sonification works for most of the example images we use and the horse example was filtered both as a singleton and with the horse "cloned" to make a group. In both cases the small objects were filtered with no lingering speech (i.e., no dangling "contains the following objects or people").

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
