### PR TITLE
adding new static text and following renames

### DIFF
--- a/handlers/photo-audio-haptics-handler/src/utils.ts
+++ b/handlers/photo-audio-haptics-handler/src/utils.ts
@@ -48,7 +48,7 @@ type ObjGroup = {
 // Geometry information for locating points and contours
 export type segGeometryInfo = {
     centroid: [number, number];
-    contourPoints: [number, number, number, number];
+    contourPoints: [number, number];
 }
 
 // Can contain more than one item when objects are grouped
@@ -95,7 +95,7 @@ export function generateSemSeg(semSeg: { "segments": Record<string, unknown>[] }
         newSeg["type"] = "segment";
         newSeg["label"] = newSeg["name"] as string;
 
-        const coord = segment["coord"] as [number, number, number, number];
+        const coord = segment["contours"] as [number, number];
         const centroid = segment["centroid"] as [number, number];
         const locSeg = {
             "centroid": centroid,


### PR DESCRIPTION
This PR is to reflect updates to the photo-audio-haptics-handler. 
The following changes have been made:

- adding two new static text segments to inform the user of movement to/from regions
- renaming to follow schema changes

The updated handler has been tested on unicorn against the images on the Image demo page as well as the following images: 

- https://en.wikipedia.org/wiki/File:Canyon_no_Lago_de_Furnas.jpg
- https://raw.githubusercontent.com/Shared-Reality-Lab/auditory-haptics-graphics-DotPad/main/preprocessor_JSON/photos/1_outdoor_cycling_scene/outdoor_cycling_scene.jpg?token=GHSAT0AAAAAABLKCO6OO6OCBNKRQV4WL4HUYQ772HA


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [ ] Reference the issue this is meant to fix or describe it if none exists.
- [ ] Full description of changes made.

## Pull Request Checklist

- [ ] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [ ] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [ ] The Docker image builds
- [ ] The container runs correctly when sent inputs with the changes
- [ ] No models or other large files are part of these commits
- [ ] A description of the tests already run as part of this PR is present
- [ ] CI is set up under `.github/workflows` or is not applicable
