### PR TITLE
Parallel preprocessors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             - ./config/express-common.env
         environment:
             - STORE_IMAGE_DATA=ON
+            - PARALLEL_PREPROCESSORS=ON
         group_add:
             # This should be set in an environment variable or .env
             - ${DOCKER_GID}

--- a/orchestrator/src/docker.ts
+++ b/orchestrator/src/docker.ts
@@ -45,6 +45,7 @@ export function getPreprocessorServices(containers: Docker.ContainerInfo[]) {
         return firstNum - secondNum;
     }).map(container => {
         const portLabel = container.Labels[_PORT_LABEL_];
+        const priorityLabel = Number(container.Labels[_PREPROCESSOR_LABEL_]);
         let port;
         if (portLabel !== undefined) {
             port = parseInt(portLabel, 10);
@@ -54,7 +55,7 @@ export function getPreprocessorServices(containers: Docker.ContainerInfo[]) {
         } else {
             port = 80;
         }
-        return [container.Labels["com.docker.compose.service"], port];
+        return [container.Labels["com.docker.compose.service"], port, priorityLabel];
     });
 }
 

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -87,29 +87,21 @@ async function runPreprocessorsParallel(data: Record<string, unknown>, preproces
                 controller.abort();
             }, PREPROCESSOR_TIME_MS);
             console.debug("Sending to preprocessor \"" + preprocessor[0] + "\"");
-            try {
-                fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
-                    "method": "POST",
-                    "headers": {
-                        "Content-Type": "application/json"
-                    },
-                    "body": JSON.stringify(data),
-                    "signal": controller.signal
-                }).then(r => {
-                    clearTimeout(timeout);
-                    resolve(r);
-                }).catch(err => {
-                    console.debug("Occurring in async...");
-                    console.error("Error occured fetching from " + preprocessor[0]);
-                    console.error(err);
-                    resolve();
-                });
-            } catch (err) {
-                // Most likely a timeout
+            fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
+                "method": "POST",
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "body": JSON.stringify(data),
+                "signal": controller.signal
+            }).then(r => {
+                clearTimeout(timeout);
+                resolve(r);
+            }).catch(err => {
                 console.error("Error occured fetching from " + preprocessor[0]);
                 console.error(err);
                 resolve();
-            }
+            });
         });
         promises.push(promise);
     }

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -185,6 +185,7 @@ app.post("/render", (req, res) => {
                 console.debug("Running preprocessors in parallel...");
                 data = await runPreprocessorsParallel(data, preprocessors);
             } else {
+                console.debug("Running preprocessors in series...");
                 data = await runPreprocessors(data, preprocessors);
             }
 
@@ -272,7 +273,13 @@ app.post("/render/preprocess", (req, res) => {
         docker.listContainers().then(async (containers) => {
             const preprocessors = getPreprocessorServices(containers);
             const data = req.body;
-            return runPreprocessors(data, preprocessors);
+            if (process.env.PARALLEL_PREPROCESSORS === "ON" || process.env.PARALLEL_PREPROCESSORS === "on") {
+                console.debug("Running preprocessors in parallel...");
+                return runPreprocessorsParallel(data, preprocessors);
+            } else {
+                console.debug("Running preprocessors in series...");
+                return runPreprocessors(data, preprocessors);
+            }
         }).then(data => {
             if (ajv.validate("https://image.a11y.mcgill.ca/request.schema.json", data)) {
                 console.debug("Valid response generated.");


### PR DESCRIPTION
This would resolve #236 by including an environment variable (`PARALLEL_PREPROCESSORS`) that when set to `ON` or `on` will cause preprocessors within the same priority group to not block each other. This should increase speed in most cases, but may also increase resource consumption.

This has been tested on unicorn with both the `/render` and `/render/preprocess` endpoints. When off, everything runs as expected. When on, requests are sent to preprocessors in the same group without waiting for each to finish.

---

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
