### PR TITLE
Let area charts run with line handler

### DIFF
--- a/handlers/high-charts/src/server.ts
+++ b/handlers/high-charts/src/server.ts
@@ -74,7 +74,7 @@ app.post("/handler", async (req, res) => {
         const serie = series[0] as { type: string, data: Record<string, unknown>[][] };
         if (serie["data"] && serie["data"].length > 0) {
             const data = serie["data"][0];
-            if (serie["type"] === "line") {
+            if (serie["type"] === "line" || serie["type"] === "area") {
                 // We can work with this
                 console.log("Length: " + data.length);
                 let title: string;


### PR DESCRIPTION
Seems like it may work based on [the API docs](https://api.highcharts.com/highcharts/series.area), although I didn't go through much of them and it could just as easily crash on a different chart. Don't have the data so untested. Fixes #395.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [ ] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [ ] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
