### PR TITLE
Tune main sonifications to about -23 LUFS

### DIFF
--- a/preprocessors/autour/autour.py
+++ b/preprocessors/autour/autour.py
@@ -62,7 +62,7 @@ def get_map_data():
         return validated
 
     # Check if request is for a map
-    if 'coords' not in content and 'placeID' not in content:
+    if 'coordinates' not in content and 'placeID' not in content:
         logging.info("Not map content. Skipping...")
         return "", 204
 

--- a/services/supercollider-images/supercollider-service/IMAGE/IMAGE.sc
+++ b/services/supercollider-images/supercollider-service/IMAGE/IMAGE.sc
@@ -161,7 +161,7 @@ IMAGE {
             // Continuous noise for pie charts v2 from Florian
             SynthDef((\playContinuousResonzNoiseHOA++(i+1)).asSymbol, { |freq = 200, phi = 0, theta = 0, radius = 2, gain = 0, decay = 0.02, imp = 48, lag = 10|
               var sig, encoded, reverb;
-              sig = Ringz.ar(PinkNoise.ar(0.05) * Decay2.ar(Impulse.ar(imp), 0.03, 0.1), freq, decay, 0.01);
+              sig = Ringz.ar(PinkNoise.ar(0.05) * Decay2.ar(Impulse.ar(imp), 0.03, 0.1), freq, decay, 0.01) * AmpComp.kr(freq, 200);
               reverb = FreeVerb.ar(sig, 0.1, 0.3, damp: 0.6, mul: 500);
               encoded = HoaEncodeDirection.ar(reverb * gain.lagud(lag, lag),
                 theta,

--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -19,7 +19,7 @@ var autourStyle;
 "Autour-style Rendering".postln;
 
 autourStyle = { |json, ttsData, outPath, addr|
-    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro;
+    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro, baseGain=(-4.dbamp);
     timing = 0;
     score = IMAGE.newScore(order);
 
@@ -73,7 +73,8 @@ autourStyle = { |json, ttsData, outPath, addr|
                 \int4, ecPattern.at(4),
                 \theta, theta,
                 \phi, phi,
-                \gain, 0.1 * dist.linlin(0, 250, 0, -6)
+                //\gain, 0.1 * dist.linlin(0, 250, 0, -6)
+                \gain, baseGain * dist.linlin(0, 250, 0, -6).dbamp
             ]
         ]);
         timing = timing + 1.0; // TODO adjust based on length along with synthdef
@@ -87,7 +88,8 @@ autourStyle = { |json, ttsData, outPath, addr|
                 \duration, (audio.at("duration").asInteger / ttsData.sampleRate),
                 \theta, theta,
                 \phi, phi,
-                \gain, 0.2 * dist.linlin(0, 250, 0, -6)
+                //\gain, 0.2 * dist.linlin(0, 250, 0, -6)
+                \gain, baseGain * dist.linlin(0, 250, 0, -6).dbamp
             ]
         ]);
         timing = timing + (audio.at("duration").asInteger / ttsData.sampleRate);

--- a/services/supercollider-images/supercollider-service/charts/line.scd
+++ b/services/supercollider-images/supercollider-service/charts/line.scd
@@ -17,7 +17,7 @@
 var singleLineChart;
 "Single Line Chart".postln;
 singleLineChart = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, baseGain=0.5, audio, seriesData, miny, maxy;
+    var score, timing, order=5, baseGain=(-8.dbamp), audio, seriesData, miny, maxy;
     timing = 0;
     score = IMAGE.newScore(order);
     // Set up b-format decoder
@@ -72,12 +72,12 @@ singleLineChart = { |json, ttsData, outPath, addr|
                 \freq, item.at(1).linlin(miny, maxy, 100, 2000),
                 \decay, 0.0102,
                 \radius, 2.0,
-                \gain, baseGain * 0.25
+                \gain, baseGain * 0.1
             ]
         ]);
         timing = timing + 0.002;
     });
-    timing = timing + 1;
+    timing = timing + 0.1;
     score.add([timing, [0]]);
 
     // Write file

--- a/services/supercollider-images/supercollider-service/charts/pie.scd
+++ b/services/supercollider-images/supercollider-service/charts/pie.scd
@@ -17,7 +17,7 @@
  var pieChart;
  "Simple Pie Chart".postln;
  pieChart = { |json, ttsData, outPath, addr|
-     var score, timing=0, order=5, baseGain=0.5, seriesData, wedgeStart = 0;
+     var score, timing=0, order=5, baseGain=(1.dbamp), seriesData, wedgeStart = 0;
      score = IMAGE.newScore(order);
      score.add([
          timing,
@@ -61,7 +61,7 @@
          // Play sonification of wedge
          score.add([
              timing,
-             [\n_set, 1002, \gain, baseGain]
+             [\n_set, 1002, \gain, baseGain * 12.dbamp]
          ]);
          score.add([
              timing,

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -17,7 +17,7 @@
 var renderPhoto;
 "Photo Audio Rendering".postln;
 renderPhoto = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, parts, segmentInfo=Array.new, baseGain=0.5;
+    var score, timing, order=5, parts, segmentInfo=Array.new, baseGain=(0.dbamp);
     timing = 0;
     score = IMAGE.newScore(order);
 


### PR DESCRIPTION
Naturally this isn't perfect since we don't do any post processing, but this is to try and cover typical cases we've already seen. -23 LUFS is chosen since it's the standard for broadcast in many jurisdictions and, while on the Internet some sites will set it higher, this seems like a good place to set it first.

Tuning was done by adjusting a base gain for each supercollider OSC responder and tuning the different synths as necessary. Values were measured on sample files using the `ebur128` utility and checked in audacity.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
