### PR TITLE
Use FLAC with autour maps renderings

### DIFF
--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -163,7 +163,7 @@ app.post("/handler", async (req, res) => {
         scData["ttsFileName"] = inFile;
         jsonFile = filePrefix + Math.round(Date.now()) + ".json";
         await fs.writeFile(jsonFile, JSON.stringify(scData));
-        outFile = filePrefix + uuidv4() + ".wav";
+        outFile = filePrefix + uuidv4() + ".flac";
         await fs.writeFile(outFile, "");
         await fs.chmod(outFile, 0o664);
 
@@ -220,7 +220,7 @@ app.post("/handler", async (req, res) => {
         return fs.readFile(out);
     }).then(buffer => {
         // TODO detect mime type from file since we will eventually use a compressed format
-        const dataURL = "data:audio/wav;base64," + buffer.toString("base64");
+        const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
         renderings.push({
             "type_id": "ca.mcgill.a11y.image.renderer.SimpleAudio",
             "description": "Points of interest around the location in the map.",

--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -108,7 +108,7 @@ autourStyle = { |json, ttsData, outPath, addr|
         nil,
         outPath,
         sampleRate: 48000,
-        headerFormat: "WAV",
+        headerFormat: "FLAC",
         sampleFormat: "int16",
         options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {


### PR DESCRIPTION
Produce smaller files than WAV for slightly more reasonable latency on
slow connections. Bring in line with other audio parts in production.

Tested on Unicorn. Files returned and played correctly but with reduction in size as expected.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
