### PR TITLE
Switch to mp3

### DIFF
--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -163,7 +163,7 @@ app.post("/handler", async (req, res) => {
         scData["ttsFileName"] = inFile;
         jsonFile = filePrefix + Math.round(Date.now()) + ".json";
         await fs.writeFile(jsonFile, JSON.stringify(scData));
-        outFile = filePrefix + uuidv4() + ".flac";
+        outFile = filePrefix + uuidv4() + ".mp3";
         await fs.writeFile(outFile, "");
         await fs.chmod(outFile, 0o664);
 
@@ -220,7 +220,7 @@ app.post("/handler", async (req, res) => {
         return fs.readFile(out);
     }).then(buffer => {
         // TODO detect mime type from file since we will eventually use a compressed format
-        const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
+        const dataURL = "data:audio/mp3;base64," + buffer.toString("base64");
         renderings.push({
             "type_id": "ca.mcgill.a11y.image.renderer.SimpleAudio",
             "description": "Points of interest around the location in the map.",

--- a/handlers/high-charts/src/server.ts
+++ b/handlers/high-charts/src/server.ts
@@ -104,7 +104,7 @@ app.post("/handler", async (req, res) => {
                         scData["ttsFileName"] = inFile;
                         jsonFile = filePrefix + req.body["request_uuid"] + ".json";
                         await fs.writeFile(jsonFile, JSON.stringify(scData));
-                        outFile = filePrefix + uuidv4() + ".flac";
+                        outFile = filePrefix + uuidv4() + ".mp3";
                         await fs.writeFile(outFile, "");
                         await fs.chmod(outFile, 0o664);
 
@@ -113,7 +113,7 @@ app.post("/handler", async (req, res) => {
                     }).then(async () => {
                         const buffer = await fs.readFile(outFile);
                         // TODO detect mime type from file
-                        const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
+                        const dataURL = "data:audio/mp3;base64," + buffer.toString("base64");
                         const rendering = {
                             "type_id": "ca.mcgill.a11y.image.renderer.SimpleAudio",
                             "description": "Simple Line Chart",
@@ -178,14 +178,14 @@ app.post("/handler", async (req, res) => {
                         scData["ttsFileName"] = inFile;
                         jsonFile = filePrefix + req.body["request_uuid"] + ".json";
                         await fs.writeFile(jsonFile, JSON.stringify(scData));
-                        outFile = filePrefix + uuidv4() + ".flac";
+                        outFile = filePrefix + uuidv4() + ".mp3";
                         await fs.writeFile(outFile, "");
                         await fs.chmod(outFile, 0o664);
                         console.log("Forming OSC...");
                         return utils.sendOSC(jsonFile, outFile, "supercollider", scPort, "/render/charts/pie");
                     }).then(async () => {
                         const buffer = await fs.readFile(outFile);
-                        const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
+                        const dataURL = "data:audio/mp3;base64," + buffer.toString("base64");
                         const rendering = {
                             "type_id": "ca.mcgill.a11y.image.renderer.SimpleAudio",
                             "description": "Simple Pie Chart",

--- a/handlers/photo-audio-handler/src/server.ts
+++ b/handlers/photo-audio-handler/src/server.ts
@@ -165,7 +165,7 @@ app.post("/handler", async (req, res) => {
                 scData["ttsFileName"] = inFile;
                 jsonFile = filePrefix + req.body["request_uuid"] + ".json";
                 await fs.writeFile(jsonFile, JSON.stringify(scData));
-                outFile = filePrefix + uuidv4() + ".flac";
+                outFile = filePrefix + uuidv4() + ".mp3";
                 await fs.writeFile(outFile, "");
                 await fs.chmod(outFile, 0o664);
 
@@ -174,7 +174,7 @@ app.post("/handler", async (req, res) => {
             }).then(async (segArray) => {
                 const buffer = await fs.readFile(outFile);
                 // TODO detect mime type from file
-                const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
+                const dataURL = "data:audio/mp3;base64," + buffer.toString("base64");
                 if (hasSegment && segArray.length > 0) {
                     const rendering = {
                         "type_id": "ca.mcgill.a11y.image.renderer.SegmentAudio",

--- a/handlers/photo-audio-haptics-handler/src/server.ts
+++ b/handlers/photo-audio-haptics-handler/src/server.ts
@@ -166,7 +166,7 @@ app.post("/handler", async (req, res) => {
                 scData["ttsFileName"] = inFile;
                 jsonFile = filePrefix + req.body["request_uuid"] + ".json";
                 await fs.writeFile(jsonFile, JSON.stringify(scData));
-                outFile = filePrefix + uuidv4() + ".flac";
+                outFile = filePrefix + uuidv4() + ".mp3";
                 await fs.writeFile(outFile, "");
                 await fs.chmod(outFile, 0o664);
 
@@ -175,7 +175,7 @@ app.post("/handler", async (req, res) => {
             }).then(async (entities: any) => {
                 const buffer = await fs.readFile(outFile);
                 // TODO detect mime type from file
-                const dataURL = "data:audio/flac;base64," + buffer.toString("base64");
+                const dataURL = "data:audio/mp3;base64," + buffer.toString("base64");
                 if (hasAudioHaptic && entities.length > segGeometryData.length) {
                     
                     // Add the point and contour location information to each returned entity.

--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -106,15 +106,19 @@ autourStyle = { |json, ttsData, outPath, addr|
     // Write to file
     score.recordNRT(
         nil,
-        outPath,
+        outPath ++ ".wav",
         sampleRate: 48000,
-        headerFormat: "FLAC",
+        headerFormat: "WAVE",
         sampleFormat: "int16",
         options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for successful write (file exists)
             if(File.exists(outPath),
-                { addr.sendMsg(\status, \done); },
+                {
+                    ("lame -v" + outPath ++ ".wav" + outPath).systemCmd;
+                    File.delete(outPath ++ ".wav");
+                    addr.sendMsg(\status, \done);
+                },
                 {
                     "Failed to write file!".postln;
                     addr.sendMsg(\status, \fail);

--- a/services/supercollider-images/supercollider-service/charts/line.scd
+++ b/services/supercollider-images/supercollider-service/charts/line.scd
@@ -83,15 +83,19 @@ singleLineChart = { |json, ttsData, outPath, addr|
     // Write file
     score.recordNRT(
         nil,
-        outPath,
+        outPath ++ ".wav",
         sampleRate: 48000,
-        headerFormat: "FLAC",
+        headerFormat: "WAVE",
         sampleFormat: "int16",
         options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for successful write (file exists)
             if(File.exists(outPath),
-                { addr.sendMsg(\status, \done); },
+                {
+                    ("lame -v" + outPath ++ ".wav" + outPath).systemCmd;
+                    File.delete(outPath ++ ".wav");
+                    addr.sendMsg(\status, \done);
+                },
                 {
                     "Failed to write file in NRT!".postln;
                     addr.sendMsg(\status, \fail);

--- a/services/supercollider-images/supercollider-service/charts/pie.scd
+++ b/services/supercollider-images/supercollider-service/charts/pie.scd
@@ -87,14 +87,18 @@
      score.add([timing, [0]]);
      score.recordNRT(
          nil,
-         outPath,
+         outPath ++ ".wav",
          sampleRate: 48000,
-         headerFormat: "FLAC",
+         headerFormat: "WAVE",
          sampleFormat: "int16",
          options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
          action: {
              if(File.exists(outPath),
-                { addr.sendMsg(\status, \done); },
+                {
+                    ("lame -v" + outPath ++ ".wav" + outPath).systemCmd;
+                    File.delete(outPath ++ ".wav");
+                    addr.sendMsg(\status, \done);
+                },
                 {
                     "Failed to write file in NRT!".postln;
                     addr.sendMsg(\status, \fail);

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -178,15 +178,19 @@ renderPhoto = { |json, ttsData, outPath, addr|
     // Write file
     score.recordNRT(
         nil,
-        outPath,
+        outPath ++ ".wav",
         sampleRate: 48000,
-        headerFormat: "FLAC",
+        headerFormat: "WAVE",
         sampleFormat: "int16",
         options: ServerOptions.new.numOutputBusChannels_(2).verbosity_(-1),
         action: {
             // Check for successful write (file exists)
             if(File.exists(outPath),
-                { addr.sendMsg(\status, \done, *segmentInfo); },
+                {
+                    ("lame -v" + outPath ++ ".wav" + outPath).systemCmd;
+                    File.delete(outPath ++ ".wav");
+                    addr.sendMsg(\status, \done, *segmentInfo);
+                },
                 {
                     "Failed to write file in NRT!".postln;
                     addr.sendMsg(\status, \fail);


### PR DESCRIPTION
Resolve #405. Note that SuperCollider does not natively support MP3 and the [MP3 quark](https://github.com/supercollider-quarks/MP3) doesn't seem to provide an easy way to work with NRT. Instead, we're just calling [LAME](https://lame.sourceforge.io/) directly, which is what the quark would do under the hood anyway.

This involves changing writing and adding a conversion step in SuperCollider and changing from FLAC to MP3 output files in the respective handlers. The process was tested with the photo audio handler ~. The others should just work with the same changes.~, the autour handler, and the high charts handler.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
