### PR TITLE
SC READMEs and OCI documentation labels

### DIFF
--- a/.github/workflows/autour-handler.yml
+++ b/.github/workflows/autour-handler.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Handler Autour
             org.opencontainers.image.description=Point of interest renderings for data from the autour server.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/handlers/autour-handler/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/autour.yml
+++ b/.github/workflows/autour.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Preprocessor Autour
             org.opencontainers.image.description=Gets information from the Autour server for use in IMAGE.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/preprocessors/autour/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/content-categoriser.yml
+++ b/.github/workflows/content-categoriser.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Preprocessor Content Categoriser
             org.opencontainers.image.description=Categorizes graphic inputs as photographs or charts.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/preprocessors/content-categoriser/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/espnet-tts.yml
+++ b/.github/workflows/espnet-tts.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Service ESPnet TTS
             org.opencontainers.image.description=TTS service for IMAGE using ESPnet
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/espnet-tts/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/grouping.yml
+++ b/.github/workflows/grouping.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Preprocessor Grouping
             org.opencontainers.image.description=Grouping of detected objects by type.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/preprocessors/grouping/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/high-charts-handler.yml
+++ b/.github/workflows/high-charts-handler.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Handler High Charts
             org.opencontainers.image.description=Basic charts renderings from raw high charts data.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/handlers/high-charts/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/motd.yml
+++ b/.github/workflows/motd.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Handler Message of the Day
             org.opencontainers.image.description=Status messages for the running IMAGE server
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/handlers/motd/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Orchestrator
             org.opencontainers.image.description=Orchestrator for an IMAGE server instance. This manages handlers and preprocessors.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/orchestrator/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/photo-audio-handler.yml
+++ b/.github/workflows/photo-audio-handler.yml
@@ -77,6 +77,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Handler Photo Audio
             org.opencontainers.image.description=Handler using multiple preprocessors to generate text or audio renderings for photographs.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/handlers/photo-audio-handler/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/semantic-segmentation.yml
+++ b/.github/workflows/semantic-segmentation.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Preprocessor Semantic Segmentation
             org.opencontainers.image.description=Semantic segmentation preprocessor for IMAGE.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/preprocessors/semanticSeg/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/supercollider-extra.yml
+++ b/.github/workflows/supercollider-extra.yml
@@ -35,7 +35,8 @@ jobs:
           labels: |
             org.opencontainers.image.title=SuperCollider Extra
             org.opencontainers.image.description=SuperCollider built with plugins and including additional resources for higher-order ambisonics
-            org.opencontainers.authors=IMAGE Project<image@cim.mcgill.ca>
+            org.opencontainers.image.authors=IMAGE Project<image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/supercollider-images/supercollider-extra/README.md
             maintainer=IMAGE Project <image@cim.mcgill.ca>
 
       - name: Build and push

--- a/.github/workflows/supercollider-image.yml
+++ b/.github/workflows/supercollider-image.yml
@@ -36,6 +36,7 @@ jobs:
             org.opencontainers.image.title=SuperCollider
             org.opencontainers.image.description=An unofficial containerization of SuperCollider
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/supercollider-images/supercollider/README.md
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/supercollider-service.yml
+++ b/.github/workflows/supercollider-service.yml
@@ -50,6 +50,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Service Supercollider
             org.opencontainers.image.description=Supercollider-based service for audio synthesis used in IMAGE.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/supercollider-images/supercollider-service/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/.github/workflows/yolo.yml
+++ b/.github/workflows/yolo.yml
@@ -70,6 +70,7 @@ jobs:
             org.opencontainers.image.title=IMAGE Preprocessor Object Detection
             org.opencontainers.image.description=Object detection for IMAGE using YOLOv5.
             org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.documentation=https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/preprocessors/yolo/README.md
             org.opencontainers.image.licenses=AGPL-3.0-or-later
             maintainer=IMAGE Project <image@cim.mcgill.ca>
       - name: Build and push

--- a/services/supercollider-images/supercollider-alpine/README.md
+++ b/services/supercollider-images/supercollider-alpine/README.md
@@ -1,0 +1,6 @@
+# SuperCollider on Alpine Linux [WORK IN PROGRESS]
+
+This is supposed to be a version of the [base SuperCollider image](../supercollider) built using [Alpine linux](https://www.alpinelinux.org/) to create a small version.
+However, it currently does not work due to [parts of SuperCollider assuming it will use glibc and not being fully POSIX compliant](https://github.com/supercollider/supercollider/issues/5197).
+Alpine linux uses [MUSL](https://musl.libc.org/) and therefore doesn't run SuperCollider correctly.
+Once this problem is fixed, it *should* work.

--- a/services/supercollider-images/supercollider-extra/README.md
+++ b/services/supercollider-images/supercollider-extra/README.md
@@ -1,0 +1,10 @@
+# SuperCollider "Extra" Docker Image
+
+This is an image build using the [base SuperCollider image](../supercollider) that includes extra features useful, but not specific to, the IMAGE project.
+In addition to the base image,
+
+* utilities for MP3 and OGG are installed (`lame` and `vorbis-tools`);
+* [sc3-plugins](https://github.com/supercollider/sc3-plugins) is installed with the version specified by the `VERSION` build argument;
+* the MP3, ATK, SC-HOA, and Vowel quarks and their dependencies are installed.
+
+Note that some dependencies are removed that don't work on a headless setup (i.e., PointView and parts of ws-lib).

--- a/services/supercollider-images/supercollider/README.md
+++ b/services/supercollider-images/supercollider/README.md
@@ -1,0 +1,15 @@
+# SuperCollider Docker Image
+
+This is a docker image of [SuperCollider](https://supercollider.github.io/) using [Fedora linux](https://getfedora.org).
+It was built for IMAGE to perform non-realtime synthesis in a containerized environment, however it could be used for other purposes.
+It is worth noting that we do not connect an audio device to it and it works by detecting the dummy device in pipewire.
+If using plain JACK, it would fail with no devices.
+This means that, by default, you will not be able to hear audio on any output device using this image.:
+
+The version of SuperCollider built with this is controlled using the `VERSION` argument.
+We typically try to keep this updated to the latest release of SuperCollider.
+If you want to change this, run
+```
+docker build --build-arg VERSION=[version] .
+```
+where `[version]` is either a branch or tag on the [SuperCollider git repository](https://github.com/supercollider/supercollider).


### PR DESCRIPTION
Add readmes to the miscellaneous SC images. For images being built automatically that have READMEs available right now, add those to the [OCI documentation label](https://github.com/opencontainers/image-spec/blob/main/annotations.md). Part of #366. Checks not listed due to documentation only changes.