### PR TITLE
fix typos and link for photo-audio-handler readme

### DIFF
--- a/handlers/photo-audio-handler/README.md
+++ b/handlers/photo-audio-handler/README.md
@@ -4,9 +4,9 @@
 
 ## What is this?
 
-This is a [handler](https://github.com/Shared-Reality-Lab/IMAGE-server/wiki/2.-Handlers,-Preprocessors-and-Services#handlers=) component that creates a sptialized audio scene to convey detected objects and detected semantic segments.
+This is a [handler](https://github.com/Shared-Reality-Lab/IMAGE-server/wiki/2.-Handlers,-Preprocessors-and-Services#handlers=) component that creates a spatialized audio scene to convey detected objects and detected semantic segments.
 
-Data from these two sources are used to create plain text description.
+Data from these two sources are used to create a plain text description.
 This description is used to create a text-to-speech rendering using [ESPnet](../../services/espnet-tts)
-which is then passed to [SuperCollider](../../services/supercollider-service/photo.scd).
+which is then passed to [SuperCollider](../../services/supercollider-images/supercollider-service/photo.scd).
 For audio, it will be opportunistically returned as segmented audio. Otherwise, it will just return a simple audio rendering.


### PR DESCRIPTION
Fixes what I think are a couple of typos/grammatical mistakes and fixes the link to the SuperCollider photo.scd file.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [ ] Reference the issue this is meant to fix or describe it if none exists.
- [ ] Full description of changes made.

## Pull Request Checklist

- [ ] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [ ] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [ ] The Docker image builds
- [ ] The container runs correctly when sent inputs with the changes
- [ ] No models or other large files are part of these commits
- [ ] A description of the tests already run as part of this PR is present
- [ ] CI is set up under `.github/workflows` or is not applicable
