### PR TITLE
Initial commit for SVG visualization schema.

### DIFF
--- a/renderers/svglayers.schema.json
+++ b/renderers/svglayers.schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/renderers/svglayers.schema.json",
+    "title": "Layered SVG Renderer",
+    "type": "object",
+    "description": "Overlay visualization of data from an input graphic, possibly containing multiple layers.",
+    "definitions": {
+        "svgLayer": {
+            "description": "A single SVG graphic encoded as a data URL.",
+            "type": "string",
+            "pattern": "^data:image/svg\+xml.+$"
+        }
+    },
+    "properties": {
+        "layers": {
+            "description": "The layer(s) representing data. It should be possible to overlay each layer on the original graphic to meaningfully convey the desired information.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "svg": { "$ref": "#/definitions/svgLayer" },
+                    "label": {
+                        "type": "string",
+                        "maxLength": 300,
+                        "description": "A short, descriptive label for the SVG in this layer."
+                    }
+                },
+                "required": [ "svg", "label" ]
+            },
+            "minItems": 1
+        },
+        "description": {
+            "description": "Optional. A short, description of the overall information contained in the layers.",
+            "type": "string",
+            "maxLength": 500
+        }
+    },
+    "required": [ "layers" ]
+}

--- a/renderers/svglayers.schema.json
+++ b/renderers/svglayers.schema.json
@@ -3,12 +3,12 @@
     "$id": "https://image.a11y.mcgill.ca/renderers/svglayers.schema.json",
     "title": "Layered SVG Renderer",
     "type": "object",
-    "description": "Overlay visualization of data from an input graphic, possibly containing multiple layers.",
+    "description": "Data for verlay visualization of data from an input graphic, possibly containing multiple layers. ca.mcgill.a11y.image.renderer.SVGLayers.",
     "definitions": {
         "svgLayer": {
             "description": "A single SVG graphic encoded as a data URL.",
             "type": "string",
-            "pattern": "^data:image/svg\+xml.+$"
+            "pattern": "^data:image\/svg\+xml(;base64)?,[^ :/?#[\]@!$&'()*+,;=]+$"
         }
     },
     "properties": {

--- a/renderers/svglayers.schema.json
+++ b/renderers/svglayers.schema.json
@@ -8,7 +8,7 @@
         "svgLayer": {
             "description": "A single SVG graphic encoded as a data URL.",
             "type": "string",
-            "pattern": "^data:image\/svg\+xml(;base64)?,[^ :/?#[\]@!$&'()*+,;=]+$"
+            "pattern": "^data:image\/svg\\+xml(;base64)?,[^ :/?#[\\]@!$&'()*+,;=]+$"
         }
     },
     "properties": {

--- a/renderers/svglayers.schema.json
+++ b/renderers/svglayers.schema.json
@@ -3,7 +3,7 @@
     "$id": "https://image.a11y.mcgill.ca/renderers/svglayers.schema.json",
     "title": "Layered SVG Renderer",
     "type": "object",
-    "description": "Data for verlay visualization of data from an input graphic, possibly containing multiple layers. ca.mcgill.a11y.image.renderer.SVGLayers.",
+    "description": "Data for overlay visualization of data from an input graphic, possibly containing multiple layers. ca.mcgill.a11y.image.renderer.SVGLayers.",
     "definitions": {
         "svgLayer": {
             "description": "A single SVG graphic encoded as a data URL.",

--- a/renderers/svglayers.schema.json
+++ b/renderers/svglayers.schema.json
@@ -21,7 +21,7 @@
                     "svg": { "$ref": "#/definitions/svgLayer" },
                     "label": {
                         "type": "string",
-                        "maxLength": 300,
+                        "maxLength": 150,
                         "description": "A short, descriptive label for the SVG in this layer."
                     }
                 },


### PR DESCRIPTION
An SVG visualization schema to resolve #442.

In brief, the current implementation is called `ca.mcgill.a11y.image.renderer.SVGLayers`. It is an object with two keys: `layers`, which is an array containing objects that include a `label` for the layer and an `svg` encoding the SVG as a data URL; and `description` which optionally provides a description of the kind of information returned across the layers. I.e., an explanation of the preprocessor and any non-obvious visualization decisions made for its output data.

Tests aside from schema compilation have not been run at this time.
