### PR TITLE
Added schema for action recognition

### DIFF
--- a/preprocessors/action-recognition.schema.json
+++ b/preprocessors/action-recognition.schema.json
@@ -11,43 +11,44 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "ObjectID":{
+                    "ObjectID": {
+                        "description": "The ID of the object against which the outputs are generated",
                         "type": "number"
                     },
                     "possible_action": {
-                      "type":"array",
-                        "items":{
-                        "type": "object",
-                        "properties": {
-                            "action":{
-                                "type":"string",
-                                "minimum": 0
-                            },
-                            "confidence":{
-                                "type":"number"
+                        "description": "An array of possible actions performed by the object. This includes the confidence and actions.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "action": {
+                                    "type": "string"
+                                },
+                                "confidence": {
+                                    "type": "number"
+                                }
                             }
-                        }
                         }
                     },
                     "possible_position": {
-                      "type":"array",
-                        "items":{
-                        "type":"object",
-                        "properties": {
-                            "position":{
-                                "type":"string"
-                            },
-                            "confidence":{
-                                "type":"number"
+                        "description": "An array of possible positions for the object. This includes confidence and the position of object.",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "position": {
+                                    "type": "string"
+                                },
+                                "confidence": {
+                                    "type": "number"
+                                }
                             }
-                        } 
                         }
-                    }    
-                    },
-                "required": [ "ObjectID","possible_action","possible_position" ]  
-                }
+                    }
+                },
+                "required": ["ObjectID", "possible_action", "possible_position"]
+            }
         }
     },
     "required": ["position_action"]
 }
-

--- a/preprocessors/action-recognition.schema.json
+++ b/preprocessors/action-recognition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://image.a11y.mcgill.ca/preprocessors/grouping.schema.json",
+    "$id": "https://image.a11y.mcgill.ca/preprocessors/action-recognition.schema.json",
     "type": "object",
     "title": "Action Recognition Data",
     "description": "The action and position of the person",

--- a/preprocessors/action-recognition.schema.json
+++ b/preprocessors/action-recognition.schema.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/preprocessors/grouping.schema.json",
+    "type": "object",
+    "title": "Action Recognition Data",
+    "description": "The action and position of the person",
+    "properties": {
+        "position_action": {
+            "description": "The information regarding the position(sitting/standing) and the possible action person is performing",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ObjectID":{
+                        "type": "number"
+                    },
+                    "possible_action": {
+                      "type":"array",
+                        "items":{
+                        "type": "object",
+                        "properties": {
+                            "action":{
+                                "type":"string",
+                                "minimum": 0
+                            },
+                            "confidence":{
+                                "type":"number"
+                            }
+                        }
+                        }
+                    },
+                    "possible_position": {
+                      "type":"array",
+                        "items":{
+                        "type":"object",
+                        "properties": {
+                            "position":{
+                                "type":"string"
+                            },
+                            "confidence":{
+                                "type":"number"
+                            }
+                        } 
+                        }
+                    }    
+                    },
+                "required": [ "ObjectID","possible_action","possible_position" ]  
+                }
+        }
+    },
+    "required": ["position_action"]
+}
+


### PR DESCRIPTION
Their PR is wrt to #460. The PR tries to create a schema for the action recognition model. The expected output of the schema is as follows

```
{
  "position_action": [
    {
      "ObjectID": 1,
      "possible_action": [
        {
          "action": "feeding",
          "confidence": 0.99
        },
        {
          "action": "mowing the lawn",
          "confidence": 0.59
        }
      ],
      "possible_position": [
        {
          "position": "standing",
          "confidence": 0.99
        }
      ]
    },
    {
      "ObjectID": 2,
      "possible_action": [
        {
          "action": "sleeping",
          "confidence": 0.59
        }
      ],
      "possible_position": [
        {
          "position": "sitting",
          "confidence": 0.99
        }
      ]
    }
  ]
}
```