### PR TITLE
Boost gain for SuperCollider scripts

### DIFF
--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -19,7 +19,7 @@ var autourStyle;
 "Autour-style Rendering".postln;
 
 autourStyle = { |json, ttsData, outPath, addr|
-    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro, baseGain=(-4.dbamp);
+    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro, baseGain=(1.dbamp);
     timing = 0;
     score = IMAGE.newScore(order);
 

--- a/services/supercollider-images/supercollider-service/autour.scd
+++ b/services/supercollider-images/supercollider-service/autour.scd
@@ -19,7 +19,7 @@ var autourStyle;
 "Autour-style Rendering".postln;
 
 autourStyle = { |json, ttsData, outPath, addr|
-    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro, baseGain=(1.dbamp);
+    var dMeters, score, timing, order=5, length=5, nTones=3, earconList, places, lat, lon, poiDelay=0.5, endDelay=0.5, intro, baseGain=(-4.dbamp);
     timing = 0;
     score = IMAGE.newScore(order);
 

--- a/services/supercollider-images/supercollider-service/charts/line.scd
+++ b/services/supercollider-images/supercollider-service/charts/line.scd
@@ -17,7 +17,7 @@
 var singleLineChart;
 "Single Line Chart".postln;
 singleLineChart = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, baseGain=(-8.dbamp), audio, seriesData, miny, maxy;
+    var score, timing, order=5, baseGain=(-1.dbamp), audio, seriesData, miny, maxy;
     timing = 0;
     score = IMAGE.newScore(order);
     // Set up b-format decoder

--- a/services/supercollider-images/supercollider-service/charts/line.scd
+++ b/services/supercollider-images/supercollider-service/charts/line.scd
@@ -17,7 +17,7 @@
 var singleLineChart;
 "Single Line Chart".postln;
 singleLineChart = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, baseGain=(-1.dbamp), audio, seriesData, miny, maxy;
+    var score, timing, order=5, baseGain=(-4.dbamp), audio, seriesData, miny, maxy;
     timing = 0;
     score = IMAGE.newScore(order);
     // Set up b-format decoder

--- a/services/supercollider-images/supercollider-service/charts/pie.scd
+++ b/services/supercollider-images/supercollider-service/charts/pie.scd
@@ -17,7 +17,7 @@
  var pieChart;
  "Simple Pie Chart".postln;
  pieChart = { |json, ttsData, outPath, addr|
-     var score, timing=0, order=5, baseGain=(1.dbamp), seriesData, wedgeStart = 0;
+     var score, timing=0, order=5, baseGain=(5.dbamp), seriesData, wedgeStart = 0;
      score = IMAGE.newScore(order);
      score.add([
          timing,

--- a/services/supercollider-images/supercollider-service/photo.scd
+++ b/services/supercollider-images/supercollider-service/photo.scd
@@ -17,7 +17,7 @@
 var renderPhoto;
 "Photo Audio Rendering".postln;
 renderPhoto = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, parts, segmentInfo=Array.new, baseGain=(0.dbamp);
+    var score, timing, order=5, parts, segmentInfo=Array.new, baseGain=(5.dbamp);
     timing = 0;
     score = IMAGE.newScore(order);
 


### PR DESCRIPTION
Fixes #477. Currently based on a comparison with the audio as recorded at full volume and NVDA on a Windows VM. A boost of 5 dB to the base values for each file (photos, autour maps, line charts, and pie charts) were applied. It sounds good to me with a quick test, but there may be some outliers so I'm holding off on marking this ready until it gets some more exposure.

---

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
