### PR TITLE
OCR enclosed-by optional key for lines of text

### DIFF
--- a/.github/workflows/ocr.yml
+++ b/.github/workflows/ocr.yml
@@ -2,7 +2,7 @@ name: OCR Preprocessor
 on:
   push:
     branches: [ main ]
-    tags: [ "preprocessor-ocr-clouds-[0-9]+.[0-9]+.[0-9]+" ]
+    tags: [ "preprocessor-ocr-enclosed-by-[0-9]+.[0-9]+.[0-9]+" ]
     paths: [ "preprocessors/ocr/**" ]
   pull_request:
     branches: [ main ]
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: shared-reality-lab/image-preprocessor-ocr-clouds
+  IMAGE_NAME: shared-reality-lab/image-preprocessor-ocr-enclosed-by
 jobs:
   lint:
     name: PEP 8 style check.
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Correct Tags
         run: |
-          if [[ ${{ github.ref }} =~ ^refs/tags/preprocessor-ocr-clouds-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ${{ github.ref }} =~ ^refs/tags/preprocessor-ocr-enclosed-by-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "TAGGED=true" >> $GITHUB_ENV
           else
             echo "TAGGED=false" >> $GITHUB_ENV
@@ -63,7 +63,7 @@ jobs:
           flavor: |
             latest=${{ env.TAGGED }}
           tags: |
-            type=match,enable=${{ env.TAGGED }},priority=300,pattern=preprocessor-ocr-clouds-(\d+.\d+.\d+),group=1
+            type=match,enable=${{ env.TAGGED }},priority=300,pattern=preprocessor-ocr-enclosed-by-(\d+.\d+.\d+),group=1
             type=raw,priority=200,value=unstable
             type=raw,priority=100,value=${{ env.timestamp }}
           labels: |

--- a/build.yml
+++ b/build.yml
@@ -31,11 +31,11 @@ services:
             context: .
             dockerfile: ./preprocessors/autour/Dockerfile
         image: "autour:latest"
-    ocr-clouds-preprocessor:
+    ocr-enclosed-by-preprocessor:
         build:
             context: .
             dockerfile: ./preprocessors/ocr/Dockerfile
-        image: "ocr-clouds:latest"
+        image: "ocr-enclosed-by:latest"
     hello-handler:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,8 @@ services:
         labels:
             ca.mcgill.a11y.image.preprocessor: 2
             ca.mcgill.a11y.image.port: 5000
-    ocr-clouds-preprocessor:
-        image: ghcr.io/shared-reality-lab/image-preprocessor-ocr-clouds:unstable
+    ocr-enclosed-by-preprocessor:
+        image: ghcr.io/shared-reality-lab/image-preprocessor-ocr-enclosed-by:unstable
         env_file:
             - ./config/apis-and-selection.env
         labels:

--- a/preprocessors/ocr/README.md
+++ b/preprocessors/ocr/README.md
@@ -13,10 +13,10 @@ Either way, it returns regions of text with corresponding bounding boxes in norm
 Note that the return codes and body used by the APIs do not necessarily match [those specified for IMAGE preprocessors](https://github.com/Shared-Reality-Lab/IMAGE-server/wiki/2.-Handlers,-Preprocessors-and-Services#preprocessors=).
 ## API selection feature
 The desired cloud service is determined by an environment variable called `CLOUD_SERVICE`, it is a string and the possible values are:
-* `CLOUD_SERVICE="OCR_AZURE"`
-* `CLOUD_SERVICE="READ_AZURE"`
-* `CLOUD_SERVICE="VISION_GOOGLE"`
-* `CLOUD_SERVICE="OCR_FREE"`
+* `CLOUD_SERVICE="AZURE_OCR"`
+* `CLOUD_SERVICE="AZURE_READ"`
+* `CLOUD_SERVICE="GOOGLE_VISION"`
+* `CLOUD_SERVICE="FREE_OCR"`
 
 The path to an environment file containing this variable should be provided in the `docker-compose.yml`, right in the `env_file` field of the `ocr-clouds-preprocessor` service.
 ## Environment setup
@@ -45,6 +45,7 @@ Here are some helpful facts about the APIs that can be used for this preprocesso
 * It recognizes text from many languages, but less than with Azure's OCR API.
 * Uses the latest recognition models.
 * It is optimized for files with significant amount of text and visual noise, as well as handwriting.
+* [Here](https://learn.microsoft.com/en-us/rest/api/computervision/3.1/get-read-result/get-read-result?tabs=HTTP) is a sample response.
 
 [Here](https://learn.microsoft.com/en-us/training/modules/read-text-computer-vision/2-ocr-azure) is more information on the differences between Microsoft Azure's APIs.
 ### Google Cloud Vision API

--- a/preprocessors/ocr/ocr.py
+++ b/preprocessors/ocr/ocr.py
@@ -24,10 +24,11 @@ import io
 import base64
 from flask import Flask, request, jsonify
 from ocr_utils import (
-    process_read_azure,
-    process_ocr_azure,
-    process_ocr_free,
-    process_vision_google
+    process_azure_read,
+    process_azure_ocr,
+    process_free_ocr,
+    process_google_vision,
+    find_obj_enclosing
 )
 
 app = Flask(__name__)
@@ -87,7 +88,12 @@ def get_ocr_text():
     if ocr_result is None:
         return jsonify("Could not retreive Azure results"), 500
 
-    name = 'ca.mcgill.a11y.image.preprocessor.ocrClouds'
+    od = 'ca.mcgill.a11y.image.preprocessor.objectDetection'
+    preprocessors = content['preprocessors']
+    if od in preprocessors and len(preprocessors[od]['objects']) > 0:
+        ocr_result = find_obj_enclosing(od, preprocessors[od], ocr_result)
+
+    name = 'ca.mcgill.a11y.image.preprocessor.ocrEnclosedBy'
     request_uuid = content['request_uuid']
     timestamp = int(time.time())
     data = {'lines': ocr_result, 'cloud_service': cld_srv_optn}
@@ -127,17 +133,17 @@ def analyze_image(source, width, height, cld_srv_optn):
     binary = base64.b64decode(image_b64)
     stream = io.BytesIO(binary)
 
-    if cld_srv_optn == "READ_AZURE":
-        return process_read_azure(stream, width, height)
+    if cld_srv_optn == "AZURE_READ":
+        return process_azure_read(stream, width, height)
 
-    elif cld_srv_optn == "OCR_AZURE":
-        return process_ocr_azure(stream, width, height)
+    elif cld_srv_optn == "AZURE_OCR":
+        return process_azure_ocr(stream, width, height)
 
-    elif cld_srv_optn == "OCR_FREE":
-        return process_ocr_free(source, width, height)
+    elif cld_srv_optn == "FREE_OCR":
+        return process_free_ocr(source, width, height)
 
-    elif cld_srv_optn == "VISION_GOOGLE":
-        return process_vision_google(image_b64, width, height)
+    elif cld_srv_optn == "GOOGLE_VISION":
+        return process_google_vision(image_b64, width, height)
 
 
 if __name__ == "__main__":

--- a/preprocessors/ocr/ocr_utils.py
+++ b/preprocessors/ocr/ocr_utils.py
@@ -63,7 +63,7 @@ def process_read_azure(stream, width, height):
                 line_text = line.text
                 # Get normalized bounding box for each line
                 bbx = line.bounding_box
-                bg_bx = [bbx[0], bbx[7], (bbx[2]-bbx[0]), (bbx[5]-bbx[3])]
+                bg_bx = [bbx[0], bbx[1], (bbx[2]-bbx[0]), (bbx[5]-bbx[3])]
                 bounding_box = normalize_bdg_box(bg_bx, width, height)
                 ocr_results.append({
                     'text': line_text,
@@ -124,9 +124,8 @@ def process_ocr_free(source, width, height):
     for line in read_result['ParsedResults'][0]['TextOverlay']['Lines']:
         line_text = line['LineText']
         # Get normalized bounding box for each line
-        lnDown = line['MaxHeight'] + line['MinTop']
         lnWidth = line['Words'][-1]['Left'] - line['Words'][0]['Left']
-        bndng_bx = [line['Words'][0]['Left'], lnDown,
+        bndng_bx = [line['Words'][0]['Left'], line['MinTop'],
                     lnWidth, line['MaxHeight']]
         bounding_box = normalize_bdg_box(bndng_bx, width, height)
         ocr_results.append({
@@ -160,7 +159,7 @@ def process_vision_google(image_b64, width, height):
             - word.bounding_poly.vertices[1].y
         )
         bndng_bx = [word.bounding_poly.vertices[0].x,
-                    word.bounding_poly.vertices[3].y,
+                    word.bounding_poly.vertices[0].y,
                     wordWidth, wordHeight]
         bounding_box = normalize_bdg_box(bndng_bx, width, height)
         ocr_results.append({


### PR DESCRIPTION
For each line of text, the OCR preprocessor now includes the optional key `enclosed_by`, which is an array of dictionaries, each containing the name of certain preprocessor and the ID of its smallest structure that fully contains the line. For now this is only implemented with the object detection.
This has been tested with all the images with the `ocr` label in the testset (~60 images from the IMAGE-test-graphics repository).

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [ ] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
