### PR TITLE
OCR with enclosed_by feature: correct preprocessor order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
         env_file:
             - ./config/apis-and-selection.env
         labels:
-            ca.mcgill.a11y.image.preprocessor: 2
+            ca.mcgill.a11y.image.preprocessor: 4
             ca.mcgill.a11y.image.port: 5000
     object-detection:
         image: ghcr.io/shared-reality-lab/image-preprocessor-object-detection:unstable


### PR DESCRIPTION
I did some testing since the last PR was deployed on unicorn; turns out the _enclosed_by_ feature is not working.
It is because I changed the preprocessor order in the `docker-compose.override.yml` but not in the actual `docker-compose.yml`, so I fixed this in the last commit. It has to be stage 4 now instead of 2, because it must go **after** the object-detection preprocessor.

However, I realized the current handler does give results of objects enclosing text. This is weird because in the tests that I ran reproducing the _enclosed_by_ feature not working, the **new** handler does not give any relations between objects and text because that code was move out to the preprocessor. So I think the ocr-handler that is currently deployed is the same image as before, which does not use the new code in the file [`server.py`](https://github.com/Shared-Reality-Lab/IMAGE-server/blob/main/handlers/ocr-handler/server.py). I'm not sure if the ocr-handler has to be built again or what should be done.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
