### PR TITLE
Azure v4 preview: option for OCR API selection

### DIFF
--- a/preprocessors/ocr/ocr.py
+++ b/preprocessors/ocr/ocr.py
@@ -28,7 +28,8 @@ from ocr_utils import (
     process_azure_ocr,
     process_free_ocr,
     process_google_vision,
-    find_obj_enclosing
+    find_obj_enclosing,
+    process_azure_read_v4_preview
 )
 
 app = Flask(__name__)
@@ -135,6 +136,9 @@ def analyze_image(source, width, height, cld_srv_optn):
 
     if cld_srv_optn == "AZURE_READ":
         return process_azure_read(stream, width, height)
+
+    elif cld_srv_optn == "AZURE_READ_v4_PREVIEW":
+        return process_azure_read_v4_preview(stream, width, height)
 
     elif cld_srv_optn == "AZURE_OCR":
         return process_azure_ocr(stream, width, height)


### PR DESCRIPTION
Added a function that enables the Read API of the Azure v4 preview to be selected as an option for the OCR just by using the enviroment variable in the `apis-and-selection.env`, like the other APIs.

## Required Information

- [x] Reference the issue this is meant to fix or describe it if none exists.
- [x] Full description of changes made.

## Pull Request Checklist

- [x] Coding standards are followed (e.g., [PEP8](https://pep8.org/))
- [x] An entry exists for the container in `docker-compose.yml` or `build.yml`
- [x] The Docker image builds
- [x] The container runs correctly when sent inputs with the changes
- [x] No models or other large files are part of these commits
- [x] A description of the tests already run as part of this PR is present
- [x] CI is set up under `.github/workflows` or is not applicable
