### PR TITLE
Fixed logic for OD svg

### DIFF
--- a/handlers/svg-object-detection/od_svg.py
+++ b/handlers/svg-object-detection/od_svg.py
@@ -164,16 +164,18 @@ def handle():
             y2 = int(objects[ungrouped[i]]['dimensions'][3] * dimensions[1])
             width = abs(x2 - x1)
             height = abs(y2 - y1)
-            start_y1 = abs(dimensions[1] - y1)
+            start_y1 = abs(dimensions[1] - y1 - height)
             svg.append(
                 draw.Rectangle(
                     x1,
                     start_y1,
                     width,
                     height,
+                    stroke_width=2.5,
                     stroke="#dd4477",
                     fill_opacity=0))
             svg_layers.append({"label": category, "svg": svg.asDataUri()})
+            svg = draw.Drawing(dimensions[0], dimensions[1])
     data = {
         "layers": svg_layers
     }


### PR DESCRIPTION
This PR is for [#280](https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/280). There was an error on the logic which has been fixed.

The fix can be found on line 167

There have been additional changes in the code which should have been done in [PR 535](https://github.com/Shared-Reality-Lab/IMAGE-server/pull/535) but they were missed in that PR.

I have tested the output on a demo image. The following is the output
![image-2](https://user-images.githubusercontent.com/27781159/210331644-049a2e49-0788-430f-8b0a-c7e37364384f.png)

![image-3](https://user-images.githubusercontent.com/27781159/210331690-6e5bcede-33d9-474e-93dd-2550b8496bbc.png)
