### PR TITLE
Clear preserved files after 60 days

### DIFF
--- a/orchestrator/clean-cron
+++ b/orchestrator/clean-cron
@@ -1,2 +1,2 @@
-*/10 * * * * for f in $(find /var/log/IMAGE/ -mindepth 1 -maxdepth 1 -type d); do if [ ! -f $f/auth ]; then if [ $(($(date +%s) - $(date +%s -r $f))) -gt 3600 ]; then rm -r $f; echo "Removed $f" >> /proc/1/fd/1; fi; fi; done;
+*/10 * * * * for f in $(find /var/log/IMAGE/ -mindepth 1 -maxdepth 1 -type d); do if [ ! -f $f/auth ]; then if [ $(($(date +%s) - $(date +%s -r $f))) -gt 3600 ]; then rm -r $f; echo "Removed $f" >> /proc/1/fd/1; fi; elif [ $(($(date +%s) - $(date +%s -r $f))) -gt 5184000 ]; then rm -r $f; echo "Removing 60-day old resource $f" >> /proc/1/fd/1; fi; done;
 


### PR DESCRIPTION
This resolves #592 by deleting all files older than 60 days (5184000 seconds), even if marked that the user consented to their storage. This was tested locally by setting the value to one hour, saving a new request, and marking that it was consented to storage. Old requests lingering on my test volume were automatically deleted and logged as such, whereas the new saved request - not older than an hour at that point - was left untouched.

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
