### PR TITLE
Create initial tactile SVG schema

### DIFF
--- a/renderers/tactilesvg.schema.json
+++ b/renderers/tactilesvg.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/renderers/tactilesvg.schema.json",
+    "title": "Tactile SVG Renderer",
+    "type": "object",
+    "description": "An SVG that is displayed using a tactile display, such as a pin array. ca.mcgill.a11y.image.renderers.TactileSVG.",
+    "definitions": {
+        "svg": {
+            "description": "An SVG encoded as a data URL.",
+            "type": "string",
+            "pattern": "^data:image\/svg\\+xml(;base64)?,([^ :/?#[\\]@!$&'()*+,;=]+)|([a-zA-Z0-9+\/=]+)$"
+        }
+    },
+    "properties": {
+        "graphic": { "$ref": "#/definitions/svg" }
+    },
+    "required": [ "graphic" ]
+}


### PR DESCRIPTION
More detail is needed, but this should be enough to start working with tactile graphics. Note that this feature is _experimental_ and may receive changes that break backwards compatibility or be deprecated _without notice_.

This uses a subset of the SVG specification as a way of encoding tactile graphics with IMAGE-specific extensions related to layering and labeling (see [initial specification here](https://github.com/Shared-Reality-Lab/IMAGE-server/issues/600#issuecomment-1483242899)). This approach is inspired by the use of SVGs in the [DAISY DTB specification](https://daisy.org/activities/standards/daisy/daisy-3/z39-86-2005-r2012-specifications-for-the-digital-talking-book/).

Currently undergoing ongoing testing as part of Venissa's current work, evaluation will not complete until end of project.

Fixes #599 and fixes #600

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.
