### PR TITLE
Add stub nominatim schema

### DIFF
--- a/preprocessors/nominatim.schema.json
+++ b/preprocessors/nominatim.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/preprocessors/nominatim.schema.json",
+    "type": "object",
+    "title": "Nominatim reverse geocode data (STUB)",
+    "description": "Nominatim reverse geocode data in the jsonv2 format described at https://nominatim.org/release-docs/develop/api/Output/#jsonv2. This is a stub that may be expanded on in the future. ca.mcgill.a11y.image.preprocessor.nominatim"
+}
+


### PR DESCRIPTION
Create a stub schema file for the eventual inclusion of a nominatim reverse geocode preprocessor. Since we are just forwarding data in the [jsonv2](https://nominatim.org/release-docs/develop/api/Output/#jsonv2) format directly, this schema does not actually check anything at this point and is integrated only for consistency and future use. Tested with real coordinates (McGill, space needle) in the tentative reverse geocode preprocessor. This adds the data type `ca.mcgill.a11y.image.preprocessor.nominatim`.

Docker compose is not applicable.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
