### PR TITLE
Downgrade espnet & set version for typeguard

### DIFF
--- a/services/espnet-tts/requirements.txt
+++ b/services/espnet-tts/requirements.txt
@@ -1,4 +1,4 @@
-espnet==202304
+espnet==0.10.0
 espnet_model_zoo==0.1.7
 Flask==2.2.5
 gunicorn==20.1.0

--- a/services/espnet-tts/requirements.txt
+++ b/services/espnet-tts/requirements.txt
@@ -4,3 +4,4 @@ Flask==2.2.5
 gunicorn==20.1.0
 jsonschema==4.4.0
 parallel_wavegan==0.5.4
+typeguard==2.13.3


### PR DESCRIPTION
The upgrades to espnet and typeguard are causing various problems. We probably should update espnet at some point (as well as pytorch...), but this will get us to a working system in the meantime. Fixes #682 by setting espnet back to the version we were using and fixing typeguard to the newest version before the breaking (to us) change. Tested with requests to the `segments` and `simple` endpoints.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
