### PR TITLE
Include reverse geocode data from nominatim preprocessor in map-tactile-svg-handler

### DIFF
--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -246,7 +246,7 @@ def handle():
                                         aria_label=targetData["name"]))
             """
             renderingDescription = "Tactile rendering of map centered at "\
-            + targetData["name"]
+                + targetData["name"]
         except KeyError:
             logging.debug("Reverse geocode data unavailable")
 

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -248,8 +248,8 @@ def handle():
             renderingDescription = "Tactile rendering of map centered at "\
                 + targetData["name"]
         except KeyError as e:
-            logging.debug("Missing key " + str(e)\
-                + " in neonatim preprocessor")
+            logging.debug("Missing key " + str(e)
+                          + " in neonatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
 
     if "points_of_interest" in data:

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -248,7 +248,8 @@ def handle():
             renderingDescription = "Tactile rendering of map centered at "\
                 + targetData["name"]
         except KeyError as e:
-            logging.debug("Missing key " + str(e) + " in neonatim preprocessor")
+            logging.debug("Missing key " + str(e)\
+                + " in neonatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
 
     if "points_of_interest" in data:

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -20,8 +20,11 @@ import jsonschema
 from jsonschema.exceptions import ValidationError
 import logging
 import time
+import math
 import drawSvg as draw
+
 app = Flask(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
 
 @app.route("/handler", methods=["POST"])
@@ -98,12 +101,12 @@ def handle():
         return response
 
     dimensions = 700, 700
-    """
+    
     renderingDescription = ("Tactile rendering of map centered at latitude " +
                             str(contents["coordinates"]["latitude"]) +
                             " and longitude " +
                             str(contents["coordinates"]["longitude"]))
-    """
+    
     # List of minor street types ('footway', 'crossing' and 'steps')
     # to be filtered out to simplify the resulting rendering
     remove_streets = ["footway", "crossing", "steps"]
@@ -190,33 +193,63 @@ def handle():
 
                 g.append(p)
         svg.append(g)
-    """
-    if "ca.mcgill.a11y.image.preprocessor.autour"\
+    
+    if "ca.mcgill.a11y.image.preprocessor.nominatim"\
             in preprocessor:
         targetData= preprocessor[
-                                 "ca.mcgill.a11y.image.preprocessor.autour"]["places"]
-
-        targetNode= next((d for d in targetData if (False)), None)
-        #math.isclose(float(d["ll"].split(",")[0]), contents["coordinates"]["latitude"], rel_tol=1e-5) and math.isclose(float(d["ll"].split(",")[1]), contents["coordinates"]["longitude"], rel_tol=1e-5)), None)
-        if targetNode is not None:
+                                 "ca.mcgill.a11y.image.preprocessor.nominatim"]
+        try:
             latitude = (
-                        (targetNode["ll"].split(",")[0] - lat_min)
+                        (float(targetData["lat"]) - lat_min)
                         * scaled_latitude)
             longitude = (
-                         (targetNode["ll"].split(",")[1] - lon_min)
-                         * scaled_longitude)
+                        (float(targetData["lon"]) - lon_min)
+                        * scaled_longitude)
             svg.append(
                         draw.Circle(
-                                        longitude,
-                                        latitude,
-                                        15,
+                                    longitude,
+                                    latitude,
+                                    20,
+                                    fill='green',
+                                    stroke_width=1.5,
+                                    stroke='green',
+                                    aria_label=targetData["name"]))
+            
+            """
+            ## Using bounding box occasionally results in the whole map 
+            ## being occupied by the target POI 
+            ## e.g. when McGill University is the detected target POI
+            bb=targetData["boundingbox"]
+            logging.debug(", ".join(bb))
+            lat_start = (
+                        (float(bb[0]) - lat_min)
+                        * scaled_latitude)
+            height = (
+                        (float(bb[1]) - lat_min)
+                        * scaled_latitude
+                        - lat_start)
+            lon_start = (
+                        (float(bb[2]) - lon_min)
+                        * scaled_longitude)
+            width = (
+                        (float(bb[3]) - lon_min)
+                        * scaled_longitude
+                        -lon_start)
+            svg.append(
+                        draw.Rectangle(
+                                        lon_start,
+                                        lat_start,
+                                        width,
+                                        height,
                                         fill='red',
                                         stroke_width=1.5,
                                         stroke='red',
-                                        aria_label=targetNode["title"]))
-            renderingDescription =  "Tactile rendering of map centered at "+ targetNode["title"]
-    """
-
+                                        aria_label=targetData["name"]))
+            """
+            renderingDescription =  "Tactile rendering of map centered at "+ targetData["name"]
+        except:
+            logging.debug("No reverse geocode data available")
+    
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:
             if POI["id"] in checkPOIs and POI["cat"] == "intersection":
@@ -247,7 +280,7 @@ def handle():
                                         stroke_width=1.5,
                                         stroke='red',
                                         aria_label=label))
-
+    
     data = {"graphic": svg.asDataUri()}
     rendering = {
         "type_id": "ca.mcgill.a11y.image.renderer.TactileSVG",

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -245,10 +245,9 @@ def handle():
                                         stroke='red',
                                         aria_label=targetData["name"]))
             """
-            renderingDescription =  "Tactile rendering of map centered at "\
-                +targetData["name"]
-        except:
-            logging.debug("No reverse geocode data available")
+            renderingDescription =  "Tactile rendering of map centered at " + targetData["name"]
+        except KeyError:
+            logging.debug("Reverse geocode data unavailable")
 
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:
@@ -279,7 +278,7 @@ def handle():
                                         fill='red',
                                         stroke_width=1.5,
                                         stroke='red',
-                                        aria_label=label))    
+                                        aria_label=label))
     data = {"graphic": svg.asDataUri()}
     rendering = {
         "type_id": "ca.mcgill.a11y.image.renderer.TactileSVG",

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -247,8 +247,9 @@ def handle():
             """
             renderingDescription = "Tactile rendering of map centered at "\
                 + targetData["name"]
-        except KeyError:
-            logging.debug("Reverse geocode data unavailable")
+        except KeyError as e:
+            logging.debug("Missing key " + str(e) + " in neonatim preprocessor")
+            logging.debug("Reverse geocode data not added to response")
 
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -98,6 +98,12 @@ def handle():
         return response
 
     dimensions = 700, 700
+    """
+    renderingDescription = ("Tactile rendering of map centered at latitude " +
+                            str(contents["coordinates"]["latitude"]) +
+                            " and longitude " +
+                            str(contents["coordinates"]["longitude"]))
+    """
     # List of minor street types ('footway', 'crossing' and 'steps')
     # to be filtered out to simplify the resulting rendering
     remove_streets = ["footway", "crossing", "steps"]
@@ -184,6 +190,32 @@ def handle():
 
                 g.append(p)
         svg.append(g)
+    """
+    if "ca.mcgill.a11y.image.preprocessor.autour"\
+            in preprocessor:
+        targetData= preprocessor[
+                                 "ca.mcgill.a11y.image.preprocessor.autour"]["places"]
+
+        targetNode= next((d for d in targetData if (False)), None)
+        #math.isclose(float(d["ll"].split(",")[0]), contents["coordinates"]["latitude"], rel_tol=1e-5) and math.isclose(float(d["ll"].split(",")[1]), contents["coordinates"]["longitude"], rel_tol=1e-5)), None)
+        if targetNode is not None:
+            latitude = (
+                        (targetNode["ll"].split(",")[0] - lat_min)
+                        * scaled_latitude)
+            longitude = (
+                         (targetNode["ll"].split(",")[1] - lon_min)
+                         * scaled_longitude)
+            svg.append(
+                        draw.Circle(
+                                        longitude,
+                                        latitude,
+                                        15,
+                                        fill='red',
+                                        stroke_width=1.5,
+                                        stroke='red',
+                                        aria_label=targetNode["title"]))
+            renderingDescription =  "Tactile rendering of map centered at "+ targetNode["title"]
+    """
 
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:
@@ -219,10 +251,7 @@ def handle():
     data = {"graphic": svg.asDataUri()}
     rendering = {
         "type_id": "ca.mcgill.a11y.image.renderer.TactileSVG",
-        "description": ("Tactile rendering of map centered at latitude " +
-                        str(contents["coordinates"]["latitude"]) +
-                        " and longitude " +
-                        str(contents["coordinates"]["longitude"])),
+        "description": renderingDescription,
         "data": data}
     try:
         validator = jsonschema.Draft7Validator(

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -245,7 +245,8 @@ def handle():
                                         stroke='red',
                                         aria_label=targetData["name"]))
             """
-            renderingDescription =  "Tactile rendering of map centered at " + targetData["name"]
+            renderingDescription = "Tactile rendering of map centered at "\
+            + targetData["name"]
         except KeyError:
             logging.debug("Reverse geocode data unavailable")
 

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -246,7 +246,8 @@ def handle():
                                         stroke='red',
                                         aria_label=targetData["name"]))
             """
-            renderingDescription =  "Tactile rendering of map centered at "+ targetData["name"]
+            renderingDescription =  "Tactile rendering of map centered at "\
+                + targetData["name"]
         except:
             logging.debug("No reverse geocode data available")
     

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -20,7 +20,6 @@ import jsonschema
 from jsonschema.exceptions import ValidationError
 import logging
 import time
-import math
 import drawSvg as draw
 
 app = Flask(__name__)
@@ -101,12 +100,12 @@ def handle():
         return response
 
     dimensions = 700, 700
-    
+
     renderingDescription = ("Tactile rendering of map centered at latitude " +
                             str(contents["coordinates"]["latitude"]) +
                             " and longitude " +
                             str(contents["coordinates"]["longitude"]))
-    
+
     # List of minor street types ('footway', 'crossing' and 'steps')
     # to be filtered out to simplify the resulting rendering
     remove_streets = ["footway", "crossing", "steps"]
@@ -193,10 +192,10 @@ def handle():
 
                 g.append(p)
         svg.append(g)
-    
+
     if "ca.mcgill.a11y.image.preprocessor.nominatim"\
             in preprocessor:
-        targetData= preprocessor[
+        targetData = preprocessor[
                                  "ca.mcgill.a11y.image.preprocessor.nominatim"]
         try:
             latitude = (
@@ -214,10 +213,10 @@ def handle():
                                     stroke_width=1.5,
                                     stroke='green',
                                     aria_label=targetData["name"]))
-            
+
             """
-            ## Using bounding box occasionally results in the whole map 
-            ## being occupied by the target POI 
+            ## Using bounding box occasionally results in the whole map
+            ## being occupied by the target POI
             ## e.g. when McGill University is the detected target POI
             bb=targetData["boundingbox"]
             logging.debug(", ".join(bb))
@@ -247,10 +246,10 @@ def handle():
                                         aria_label=targetData["name"]))
             """
             renderingDescription =  "Tactile rendering of map centered at "\
-                + targetData["name"]
+                +targetData["name"]
         except:
             logging.debug("No reverse geocode data available")
-    
+
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:
             if POI["id"] in checkPOIs and POI["cat"] == "intersection":
@@ -280,8 +279,7 @@ def handle():
                                         fill='red',
                                         stroke_width=1.5,
                                         stroke='red',
-                                        aria_label=label))
-    
+                                        aria_label=label))    
     data = {"graphic": svg.asDataUri()}
     rendering = {
         "type_id": "ca.mcgill.a11y.image.renderer.TactileSVG",


### PR DESCRIPTION
When available, reverse geocode data from the nominatim preprocessor is used to render the target POI on the map SVG and also included in the description of the generated response.

This handler was tested with the following latitude-longitude coordinates:
1. {"latitude": 45.5060618, "longitude": -73.5786207}
2. {"latitude": 45.54646, "longitude": -73.49546}

SVG generated for 1. (Target POI in green):
![image](https://github.com/Shared-Reality-Lab/IMAGE-server/assets/53469681/48ab9d5c-d1a0-422e-9f76-ac17d4dec4bd)

The response was successfully received and rendered on the pin array along with the POI (in the full image) and the associated TTS label.

---
## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
