### PR TITLE
Changes in map-tactile-svg-handler to work with null name tag in nominatim response. Resolves #705

### DIFF
--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -257,7 +257,7 @@ def handle():
                           + " in nominatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
         except TypeError:
-            logging.debug("Expected to obtain string as " 
+            logging.debug("Expected to obtain string as "
                           "POI name in nominatim ")
             logging.debug("Obtained type " + str(type(targetTag)))
 

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -204,6 +204,12 @@ def handle():
             longitude = (
                         (float(targetData["lon"]) - lon_min)
                         * scaled_longitude)
+            targetTag = targetData["name"] if targetData["name"]\
+                is not None else targetData["display_name"]\
+                if targetData["display_name"]\
+                is not None else targetData["type"]
+            if type(targetTag) is not str:
+                raise TypeError 
             svg.append(
                         draw.Circle(
                                     longitude,
@@ -212,7 +218,7 @@ def handle():
                                     fill='green',
                                     stroke_width=1.5,
                                     stroke='green',
-                                    aria_label=targetData["name"]))
+                                    aria_label=targetTag))
 
             """
             ## Using bounding box occasionally results in the whole map
@@ -246,11 +252,14 @@ def handle():
                                         aria_label=targetData["name"]))
             """
             renderingDescription = "Tactile rendering of map centered at "\
-                + targetData["name"]
+                + targetTag
         except KeyError as e:
             logging.debug("Missing key " + str(e)
                           + " in neonatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
+        except TypeError as e:
+            logging.debug("Expected to obtain string as POI name in nominatim ")
+            logging.debug("Obtained type "+ str(type(targetTag)))
 
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -209,7 +209,7 @@ def handle():
                 if targetData["display_name"]\
                 is not None else targetData["type"]
             if type(targetTag) is not str:
-                raise TypeError 
+                raise TypeError
             svg.append(
                         draw.Circle(
                                     longitude,
@@ -257,9 +257,10 @@ def handle():
             logging.debug("Missing key " + str(e)
                           + " in neonatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
-        except TypeError as e:
-            logging.debug("Expected to obtain string as POI name in nominatim ")
-            logging.debug("Obtained type "+ str(type(targetTag)))
+        except TypeError:
+            logging.debug("Expected to obtain string as " 
+                          "POI name in nominatim ")
+            logging.debug("Obtained type " + str(type(targetTag)))
 
     if "points_of_interest" in data:
         for POI in data["points_of_interest"]:


### PR DESCRIPTION
Changes have been made to handle null name tag from nominatim more gracefully. Resolves #705 

When a null _name_ tag is encountered the handler should now behave as follows:
 1.  The _display_name_ is used as the POI tag if it is not null 
 2.  If _display_name_ is also null, _type_ is used as the POI tag
 3.  A TypeError Exception is thrown if the resulting tag is not a string and the POI is not rendered in the response. The latitude and longitude are used in the description (as is the case when no nominatim response is available).
 
Tested with coordinates {"latitude": 45, "longitude": -73} which has a null name tag.  Description of resulting response has:
```
"description":"Tactile rendering of map centered at 4983, Gore Road, Highgate Center, Highgate, Franklin County, Vermont, 05459, United States"
```
Tested for the same coordinates by setting display_name to null and both display_name and type to null to ensure that the response is as described in 2 and 3 respectively. 
Description of response for case 2: 
```
"description":"Tactile rendering of map centered at house"
```
Description of response for case 3: 
```
"description":"Tactile rendering of map centered at latitude 45 and longitude -73"
```
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
