### PR TITLE
Adding missed check for grouping preprocessor in photo-tactile-svg handler

### DIFF
--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -130,7 +130,7 @@ def handle():
     # or semantic segmentation is present
     svg = draw.Drawing(dimensions[0], dimensions[1])
 
-    if "ca.mcgill.a11y.image.preprocessor.objectDetection"\
+    if "ca.mcgill.a11y.image.preprocessor.objectDetection" in preprocessors\
         and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
         preprocessor_names.append('Things and people')
         o = preprocessors["ca.mcgill.a11y.image.preprocessor.objectDetection"]

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -130,7 +130,8 @@ def handle():
     # or semantic segmentation is present
     svg = draw.Drawing(dimensions[0], dimensions[1])
 
-    if "ca.mcgill.a11y.image.preprocessor.objectDetection" in preprocessors:
+    if "ca.mcgill.a11y.image.preprocessor.objectDetection"\
+        and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
         preprocessor_names.append('Things and people')
         o = preprocessors["ca.mcgill.a11y.image.preprocessor.objectDetection"]
         g = preprocessors["ca.mcgill.a11y.image.preprocessor.grouping"]

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -131,7 +131,7 @@ def handle():
     svg = draw.Drawing(dimensions[0], dimensions[1])
 
     if "ca.mcgill.a11y.image.preprocessor.objectDetection" in preprocessors\
-        and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
+            and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
         preprocessor_names.append('Things and people')
         o = preprocessors["ca.mcgill.a11y.image.preprocessor.objectDetection"]
         g = preprocessors["ca.mcgill.a11y.image.preprocessor.grouping"]


### PR DESCRIPTION
Although the photo-tactile-svg handler checked for availability of semantic segmentation preprocessor and/or object detection preprocessor along with the grouping preprocessor since the latter two are used together to generate the output svg this check was missed out in the actual code section that created the SVG. This would result in the preprocessor failing if semantic segmentation and object detection responses were present but not the grouping preprocessor (which was the point of the first check!)

Changes have been made to include this missed check.

Tested for preprocessor responses containing:
- Only semantic segmentation
- Only object detection and grouping preprocessor
- Semantic segmentation and object detection with no grouping preprocessor (previously the failure case)
to ensure that the handler does not break and generates responses for the preprocessor available.

Logging improvements handled in #709 

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
