### PR TITLE
Do not assume percentage y-values in pie chart SuperCollider 

### DIFF
--- a/services/supercollider-images/supercollider-service/charts/pie.scd
+++ b/services/supercollider-images/supercollider-service/charts/pie.scd
@@ -17,7 +17,7 @@
  var pieChart;
  "Simple Pie Chart".postln;
  pieChart = { |json, ttsData, outPath, addr|
-     var score, timing=0, order=5, baseGain=(5.dbamp), seriesData, wedgeStart = 0;
+     var score, timing=0, order=5, baseGain=(5.dbamp), seriesData, wedgeStart = 0, totalValue=0;
      score = IMAGE.newScore(order);
      score.add([
          timing,
@@ -41,11 +41,20 @@
         ]
      ]);
 
+     // Get sum of y
+     json.at("seriesData").do({ |item|
+         try {
+            totalValue = totalValue + item.at("y").asFloat;
+        } { |err|
+            err.postln;
+        }
+    });
+
      // Run through segments
      json.at("seriesData").do({ |item, i|
          var offset, duration, y;
          try {
-             y = item.at("y").asFloat;
+             y = item.at("y").asFloat / totalValue * 100;
          } { |err|
              y = 0;
          };


### PR DESCRIPTION
Resolve #712 by manually calculating a percentage for each pie chart wedge to use in determining duration of sonification rather than assuming the y-value passed is always a percentage. This still results in a fairly long sonification, but much of this is speaking the labels. Tested with the examples given in the linked issue since there aren't any others I know of.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
