### PR TITLE
Modify semseg svg path to skip intermmediate points

### DIFF
--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -221,14 +221,12 @@ def handle():
                                   fill='none', aria_label=category,)
                 for c in contour:
                     coords = c["coordinates"]
-                    for i, coord in enumerate(coords):
-                        if (i == 0):
-                            continue
+                    for i in range(1, len(coords), 5):
                         if (i == 1):
-                            p.M(coord[0] * dimensions[0],
-                                (dimensions[1] - coord[1] * dimensions[1]))
-                        p.L(coord[0] * dimensions[0],
-                            dimensions[1] - coord[1] * dimensions[1])
+                            p.M(coords[i][0] * dimensions[0],
+                                (dimensions[1] - coords[i][1] * dimensions[1]))
+                        p.L(coords[i][0] * dimensions[0],
+                            dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
 
     logging.debug("Generating final rendering")


### PR DESCRIPTION
The svg path generated by semantic segmentation has been modified to skip intermediate points in order to reduce the detail in the resulting svg. This helps to avoid the CPU usage issues seen in Shared-Reality-Lab/IMAGE-Monarch#36. 

The Android application no longer crashes for the images mentioned in the issue. 

Also, the semantic segmentation svg outline is visually very similar with the new version appearing slightly more smoothed out than the old version. 
Old version:
![image](https://github.com/Shared-Reality-Lab/IMAGE-server/assets/53469681/34ab52df-b43b-480b-81db-1e73cdb3b606)

New version:
![image](https://github.com/Shared-Reality-Lab/IMAGE-server/assets/53469681/7379e3f3-b02a-4107-a410-9654832757ec)

Resolves Shared-Reality-Lab/IMAGE-Monarch#36.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
