### PR TITLE
Integrate translation + French TTS service to `high-charts` handler

### DIFF
--- a/handlers/high-charts/src/server.ts
+++ b/handlers/high-charts/src/server.ts
@@ -65,6 +65,11 @@ app.post("/handler", async (req, res) => {
         return;
     }
 
+    // Get target language of request
+    const targetLanguage = req.body["language"];
+
+    
+    // Forming renderings
     const renderings: Record<string, unknown>[] = [];
     const highChartsData = req.body["highChartsData"];
 
@@ -78,8 +83,24 @@ app.post("/handler", async (req, res) => {
                 // We can work with this
                 console.log("Length: " + data.length);
                 try {
-                    const graphInfo = utils.getGraphInfo(highChartsData);
-                    const ttsResponse = await utils.getTTS([graphInfo]);
+                    const graphInfo:string = utils.getGraphInfo(highChartsData);
+                    // Language Translation if target language is not English
+                    if (targetLanguage !== "en") {
+                        console.debug(`Translating to ${targetLanguage}...`);
+                        const translationSegments = await fetch('http://multilang-support/service/translate', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify({
+                                "language": targetLanguage,
+                                "segments": graphInfo
+                            })
+                        }).then(resp => {
+                            return resp.json();
+                        }
+                    )};
+                    const ttsResponse = await utils.getTTS([graphInfo], targetLanguage);
                     const scData = {
                         "audio": {
                             "offset": 0,

--- a/handlers/high-charts/src/utils.ts
+++ b/handlers/high-charts/src/utils.ts
@@ -29,8 +29,18 @@ export function generateEmptyResponse(requestUUID: string): { "request_uuid": st
     };
 }
 
-export async function getTTS(text: string[]): Promise<TTSResponse> {
-    return fetch("http://espnet-tts/service/tts/segments", {
+export async function getTTS(text: string[], targetLanguage: string): Promise<TTSResponse> {
+    let ttsUrl:string;
+    if (targetLanguage === "en") {
+        ttsUrl = "http://espnet-tts/service/tts/segments";
+    } else if (targetLanguage === "fr") {
+        ttsUrl = "http://espnet-tts-fr/service/tts/segments";
+    }
+    else {
+        console.error(`Unsupported language: ${targetLanguage}`);
+        throw new Error(`Unsupported language: ${targetLanguage}`);
+    }
+    return fetch(ttsUrl, {
         "method": "POST",
         "headers": {
             "Content-Type": "application/json",


### PR DESCRIPTION
# This PR is a part of #696
## Changes made:
- Added language handling: translation + French TTS in `high-charts` handler
    - Sending `segments` to `multilang-support` service if language is not "en". (i.e., translate them to French)
    - Allowing handler to connect to `espnet-tts-fr` if the target language is French

---
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
