### PR TITLE
Fix cat Error Key in OSM Debug Handler

### DIFF
--- a/handlers/svg-open-street-map/osm-svg.py
+++ b/handlers/svg-open-street-map/osm-svg.py
@@ -256,7 +256,8 @@ def handle():
                 if ("points_of_interest" in d or
                         len(d["points_of_interest"]) != 0):
                     for points_of_interest in d["points_of_interest"]:
-                        if points_of_interest["cat"] != "intersection":
+                        if ("cat" in points_of_interest
+                                or "intersection" in points_of_interest):
                             latitude = (
                                 (points_of_interest["lat"] - lat_min)
                                 * scaled_latitude)
@@ -271,13 +272,14 @@ def handle():
                                     fill='red',
                                     stroke_width=1.5,
                                     stroke='red'))
-                            all_svg.append(
-                                draw.Text(
-                                    points_of_interest["cat"],
-                                    16,
-                                    longitude,
-                                    latitude,
-                                    fill='black'))
+                            if "cat" in points_of_interest:
+                                all_svg.append(
+                                    draw.Text(
+                                        points_of_interest["cat"],
+                                        16,
+                                        longitude,
+                                        latitude,
+                                        fill='black'))
 
                 svg_layers.append(
                     {"label": "AllLayers",


### PR DESCRIPTION
This PR addresses the key error issue raised in #719.  With the current output of the OSM preprocessor, not all the points of interest (POIs) have a ```cat```  key as shown below, so accessing those POIs without this key may generate an error.  This PR fixes that by making changes (i.e. adding logic) to code lines 259 and 275.
```
{
				"id": 5077277881,
				"lat": 45.5134966,
				"lon": -73.5573904,
				"crossing": "unmarked",
				"highway": "crossing",
				"cat": "crossing",
				"intersection": [
					109776833,
					331089332
				],
				"name": "Boulevard René-Lévesque Est intersecting Boulevard René-Lévesque Est"
			},
			{
				"id": 208962794,
				"lat": 45.5135729,
				"lon": -73.5573241,
				"intersection": [
					109776833,
					165265050
				],
				"name": "Boulevard René-Lévesque Est intersecting Boulevard René-Lévesque Est"
			}
```



Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
