### PR TITLE
Helping French TTS to pronounce numbers 

### DIFF
--- a/services/espnet-tts-fr/requirements.txt
+++ b/services/espnet-tts-fr/requirements.txt
@@ -6,3 +6,4 @@ jsonschema==4.4.0
 parallel_wavegan==0.5.5
 phonemizer
 typeguard==2.13.3
+num2words>=0.5.12

--- a/services/espnet-tts-fr/src/app.py
+++ b/services/espnet-tts-fr/src/app.py
@@ -129,7 +129,6 @@ def segment_tts():
                     segment_new.append(s)
 
             segment_new = " ".join(str(s) for s in segment_new)
-            logger.debug(f'New Segment: {segment_new}')
             wavs.append(tts(segment_new))
         for wav in wavs:
             if totalWav is not None:

--- a/services/espnet-tts-fr/src/app.py
+++ b/services/espnet-tts-fr/src/app.py
@@ -134,7 +134,7 @@ def segment_tts():
                 try:
                     segment_new.append(processSegment(s))
                 except Exception as e:
-                    logger.error(f"ERROR processing {s}")
+                    # logger.error(f"ERROR processing {s}")
                     logger.error(e)
                     segment_new.append(s)
 

--- a/services/espnet-tts-fr/src/app.py
+++ b/services/espnet-tts-fr/src/app.py
@@ -139,7 +139,6 @@ def segment_tts():
                     segment_new.append(s)
 
             segment_new = " ".join(str(s) for s in segment_new)
-            logger.debug(f"New: {segment_new}")
             wavs.append(tts(segment_new))
         for wav in wavs:
             if totalWav is not None:

--- a/services/multilang-support/src/utils.py
+++ b/services/multilang-support/src/utils.py
@@ -149,7 +149,7 @@ class Translator:
             output_query = self.decode_generated_tensor(output_tensor)
 
             # 4. Translated query -> result
-            LOGGER.info(f'Translated: "{input_query}" --> "{output_query}"')
+            # LOGGER.info(f'Translated: "{input_query}" --> "{output_query}"')
             translations.append(output_query)
         finish_translate = time.time()
         translate_time = int((finish_translate - start_translate)*1000)
@@ -185,7 +185,7 @@ if "utils" in __name__ or __name__ == "__main__":
     instantiate()
     ready_message = "Translation service is instantiated and ready!"
     LOGGER.info(ready_message)
-    # Dummy translation to test the service
+    # Dummy translation to test if the service is ready
     for lang in SUPPORTED_LANGS:
         LOGGER.info(Translator.get_translator("en", lang)
                     .translate([ready_message])[0].pop())


### PR DESCRIPTION
## Changes Made 
- Issue: #723 
- Added `num2words` library to help convert numbers in numeric form to text (e.g. "42" to "quarante deux")
- Added debugging logs indicating cases of numeric conversion: ("segment" as a part of the input string that's separated by a space)
  - Case 0: segment is numeric or float number (e.g., "2012", "23.12", "2021."). This includes case where a number is at the end of a sentence with "." as a part of the segment.
  - Case 1: segment has ",". This is due to `multilang-support` tranlated to Metropolitan French where they have a different notation system.
  - Case 2: segment is a range, containing a hyphen '-'. This is often seen in charts with age or year range. It also requires extra syntax to be added. E.g., "34-59" would be "**de** trente quatre **à** cinquante neuf". 
  - > **NOTE:** This might conflict with words in French that has hyphen, like "gratte-ciel", "arc-en-ciel", or names like "Lionel-Groulx".

## Testings
- Tested with large numbers with demimal point, year: https://etherscan.io/chart/ethersupplygrowth
- Tested with range: https://www.inspq.qc.ca/covid-19/donnees/age-sexe
- Tested with regular numbers: any graphics with countable quantity of object(s). 

---
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
