### PR TITLE
Modify tactile svg handlers to include appropriate title information in response SVG

### DIFF
--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -107,7 +107,10 @@ def handle():
                             str(contents["coordinates"]["latitude"]) +
                             " and longitude " +
                             str(contents["coordinates"]["longitude"]))
-
+    caption = ("Map centered at latitude " +
+               str(contents["coordinates"]["latitude"]) +
+               " and longitude " +
+               str(contents["coordinates"]["longitude"]))
     # List of minor street types ('footway', 'crossing' and 'steps')
     # to be filtered out to simplify the resulting rendering
     remove_streets = ["footway", "crossing", "steps", "elevator"]
@@ -255,6 +258,7 @@ def handle():
             """
             renderingDescription = "Tactile rendering of map centered at "\
                 + targetTag
+            caption = "Map centered at " + targetTag
         except KeyError as e:
             logging.debug("Missing key " + str(e)
                           + " in nominatim preprocessor")
@@ -287,6 +291,8 @@ def handle():
                                             stroke_width=1.5,
                                             stroke='red',
                                             aria_label=label))
+    title = draw.Title(caption)
+    svg.append(title)
     data = {"graphic": svg.asDataUri()}
     rendering = {
         "type_id": "ca.mcgill.a11y.image.renderer.TactileSVG",

--- a/handlers/photo-tactile-svg/requirements.txt
+++ b/handlers/photo-tactile-svg/requirements.txt
@@ -2,3 +2,4 @@ drawSvg==1.8.3
 jsonschema==4.6.0
 Flask==2.2.5
 gunicorn==20.1.0
+inflect==7.0.0

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -137,14 +137,14 @@ def handle():
     # or semantic segmentation is present
     svg = draw.Drawing(dimensions[0], dimensions[1])
     form = inflect.engine()
-    caption=""
+    caption = ""
 
     if "ca.mcgill.a11y.image.preprocessor.objectDetection" in preprocessors\
             and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
         logging.debug("Object detector and grouping preprocessor found. "
                       "Adding data to response...")
         caption = "This photo contains "
-        obj_list=[]
+        obj_list = []
         preprocessor_names.append('Things and people')
         o = preprocessors["ca.mcgill.a11y.image.preprocessor.objectDetection"]
         g = preprocessors["ca.mcgill.a11y.image.preprocessor.grouping"]
@@ -157,7 +157,7 @@ def handle():
             ids = group["IDs"]
             # Pluralize names of layers with more than 1 object
             category = form.plural(objects[ids[0]]["type"]).strip()
-            obj_list.append(str(len(ids))+ " "+ category)
+            obj_list.append(str(len(ids)) + " " + category)
             layer += 1
             g = draw.Group(data_image_layer="Layer " +
                            str(layer), aria_label=category)
@@ -185,6 +185,7 @@ def handle():
         # Loop through ungrouped objects and generate a layer for each
         for val in ungrouped:
             category = objects[val]["type"].strip()
+            # appending singular objects with appropriate article
             obj_list.append(form.a(category))
             layer += 1
             x1 = (objects[val]
@@ -210,12 +211,12 @@ def handle():
                     aria_label=category,
                     data_image_layer="Layer "+str(layer)))
 
-        if len(obj_list)>0:
-            if len(obj_list)>1:
-                obj_list[-1] = "and "+ obj_list[-1]+"." 
+        if len(obj_list) > 0:
+            if len(obj_list) > 1:
+                obj_list[-1] = "and " + obj_list[-1] + "." 
                 caption += ", ".join(obj_list)
             else:
-                caption += obj_list[0]+"."   
+                caption += obj_list[0] + "."   
 
     # Include semantic segmentation in SVG independent of the layers
     if "ca.mcgill.a11y.image.preprocessor.semanticSegmentation"\
@@ -223,9 +224,9 @@ def handle():
         logging.debug("Semantic segmentation found. "
                       "Adding data to response...")
         preprocessor_names.append("Outlines of regions")
-        obj_list=[]
+        obj_list = []
         caption += ("This photo " +
-                    ("" if len(caption)==0 else "also ") +
+                    ("" if len(caption) == 0 else "also ") +
                     "contains the following outlines of regions: ")
         s = preprocessors["ca.mcgill.a11y.image."
                           "preprocessor.semanticSegmentation"]
@@ -250,15 +251,14 @@ def handle():
                         p.L(coords[i][0] * dimensions[0],
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
-                
-        if len(obj_list)>0:
-            if len(obj_list)>1:
-                obj_list[-1] = "and "+ obj_list[-1]+"." 
+           
+        if len(obj_list) > 0:
+            if len(obj_list) > 1:
+                obj_list[-1] = "and " + obj_list[-1] + "." 
                 caption += ", ".join(obj_list)
             else:
-                caption += obj_list[0]+"."
+                caption += obj_list[0] + "."
 
-    
     title = draw.Title(caption)
     svg.append(title)
     logging.debug("Generating final rendering")

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -231,6 +231,9 @@ def handle():
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
 
+    caption=""
+    title = draw.Title(caption)
+    svg.append(title)
     logging.debug("Generating final rendering")
     data = {"graphic": svg.asDataUri()}
 

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -211,12 +211,11 @@ def handle():
                     aria_label=category,
                     data_image_layer="Layer "+str(layer)))
 
-        if len(obj_list) > 0:
-            if len(obj_list) > 1:
-                obj_list[-1] = "and " + obj_list[-1] + "."
-                caption += ", ".join(obj_list)
-            else:
-                caption += obj_list[0] + "."
+        if len(obj_list) > 1:
+            obj_list[-1] = "and " + obj_list[-1] + "."
+            caption += ", ".join(obj_list)
+        elif len(obj_list) == 1:
+            caption += obj_list[0] + "."
 
     # Include semantic segmentation in SVG independent of the layers
     if "ca.mcgill.a11y.image.preprocessor.semanticSegmentation"\

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -21,6 +21,7 @@ from jsonschema.exceptions import ValidationError
 import logging
 import time
 import drawSvg as draw
+import inflect
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.DEBUG)
@@ -135,11 +136,15 @@ def handle():
     # Initialize svg if either object detection
     # or semantic segmentation is present
     svg = draw.Drawing(dimensions[0], dimensions[1])
+    form = inflect.engine()
+    caption=""
 
     if "ca.mcgill.a11y.image.preprocessor.objectDetection" in preprocessors\
             and "ca.mcgill.a11y.image.preprocessor.grouping" in preprocessors:
         logging.debug("Object detector and grouping preprocessor found. "
                       "Adding data to response...")
+        caption = "This photo contains "
+        obj_list=[]
         preprocessor_names.append('Things and people')
         o = preprocessors["ca.mcgill.a11y.image.preprocessor.objectDetection"]
         g = preprocessors["ca.mcgill.a11y.image.preprocessor.grouping"]
@@ -150,7 +155,9 @@ def handle():
         # Loop through the object groups and generate a layer for each
         for group in grouped:
             ids = group["IDs"]
-            category = objects[ids[0]]["type"]
+            # Pluralize names of layers with more than 1 object
+            category = form.plural(objects[ids[0]]["type"]).strip()
+            obj_list.append(str(len(ids))+ " "+ category)
             layer += 1
             g = draw.Group(data_image_layer="Layer " +
                            str(layer), aria_label=category)
@@ -177,7 +184,8 @@ def handle():
 
         # Loop through ungrouped objects and generate a layer for each
         for val in ungrouped:
-            category = objects[val]["type"]
+            category = objects[val]["type"].strip()
+            obj_list.append(form.a(category))
             layer += 1
             x1 = (objects[val]
                   ['dimensions'][0] * dimensions[0])
@@ -202,18 +210,30 @@ def handle():
                     aria_label=category,
                     data_image_layer="Layer "+str(layer)))
 
+        if len(obj_list)>0:
+            if len(obj_list)>1:
+                obj_list[-1] = "and "+ obj_list[-1]+"." 
+                caption += ", ".join(obj_list)
+            else:
+                caption += obj_list[0]+"."   
+
     # Include semantic segmentation in SVG independent of the layers
     if "ca.mcgill.a11y.image.preprocessor.semanticSegmentation"\
             in preprocessors:
         logging.debug("Semantic segmentation found. "
                       "Adding data to response...")
         preprocessor_names.append("Outlines of regions")
+        obj_list=[]
+        caption += ("This photo " +
+                    ("" if len(caption)==0 else "also ") +
+                    "contains the following outlines of regions: ")
         s = preprocessors["ca.mcgill.a11y.image."
                           "preprocessor.semanticSegmentation"]
         segments = s["segments"]
         if (len(segments) > 0):
             for segment in segments:
                 category = segment["name"]
+                obj_list.append(category)
                 contour = segment["contours"]
                 try:
                     p = draw.Path(stroke="#ff4477", stroke_width=10,
@@ -230,8 +250,15 @@ def handle():
                         p.L(coords[i][0] * dimensions[0],
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
+                
+        if len(obj_list)>0:
+            if len(obj_list)>1:
+                obj_list[-1] = "and "+ obj_list[-1]+"." 
+                caption += ", ".join(obj_list)
+            else:
+                caption += obj_list[0]+"."
 
-    caption=""
+    
     title = draw.Title(caption)
     svg.append(title)
     logging.debug("Generating final rendering")

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -213,10 +213,10 @@ def handle():
 
         if len(obj_list) > 0:
             if len(obj_list) > 1:
-                obj_list[-1] = "and " + obj_list[-1] + "." 
+                obj_list[-1] = "and " + obj_list[-1] + "."
                 caption += ", ".join(obj_list)
             else:
-                caption += obj_list[0] + "."   
+                caption += obj_list[0] + "."
 
     # Include semantic segmentation in SVG independent of the layers
     if "ca.mcgill.a11y.image.preprocessor.semanticSegmentation"\
@@ -251,10 +251,10 @@ def handle():
                         p.L(coords[i][0] * dimensions[0],
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
-           
+
         if len(obj_list) > 0:
             if len(obj_list) > 1:
-                obj_list[-1] = "and " + obj_list[-1] + "." 
+                obj_list[-1] = "and " + obj_list[-1] + "."
                 caption += ", ".join(obj_list)
             else:
                 caption += obj_list[0] + "."


### PR DESCRIPTION
Modifed map and photo tactile svg handlers to include title information in the <title> node of the response SVG.
An additional title node has to be included in the response SVG. Closes #758.

The changes made are as follows:
1. Included additional 'title' node in the response SVG in both handlers
2. Maps handler: Node 'title' will contain _Map centered at {target_name}_ when a result (which can be an actual name or even a type of location) is returned by nominatim. Otherwise, it will contain _Map centered at latitude {lat} and longitude {long}_.
3. Photos handler: Node 'title' will contain _This photo contains {objects and people}. This photo {also}_  (if object detection is present)  _contains the following outlines of regions: {regions}_ 
4. Include 'inflect' in requirements to pluralize the object types when more than 1 object of a particular type is present and also include the appropriate indefinite article. 
5. The pluralized version of the object type is now also being used for the layer names i.e. a layer with multiple cats will be named 'cats' instead of 'cat' (since it's nicer and a minimal change!)

Testing:
1. Maps handler: Tested for coordinates

> - {"latitude": 45.504111, "longitude": -73.5715456}- McGill Metro
>>Response SVG contains: <title>Map centered at McGill</title>

> - {"latitude": 45, "longitude": -73}
>>Reopened old issue as nominatim is now returning an empty string instead of None for untagged coordinates! Since this string is very similar to the 'description' field this will be handled with #705 . 
>> Currently returns _<title>Map centered at </title>_ as "" is returned as the target_name

2. Photos handler: Tested for:

- > ![birds](https://github.com/Shared-Reality-Lab/IMAGE-UX/blob/main/test_images/outdoor_images/pexels-johannes-plenio-1126384.jpg?raw=true)
>> Response SVG contains:  <title>This photo contains 6 birds.This photo also contains the following outlines of regions: sky, and sand.</title>

- >Only object detection response of ![people](https://github.com/Shared-Reality-Lab/IMAGE-UX/blob/main/test_images/indoor_images/pexels-christina-morillo-1181605.jpg?raw=true) 
>> Response SVG contains:  <title>This photo contains 2 books, 2 people, a laptop, and a chair.</title>

- > Only semantic segmentation response of ![Cat ](https://www.thesprucepets.com/thmb/17UY4UpiMekV7WpeXDziXsnt7q4=/1646x0/filters:no_upscale():strip_icc()/GettyImages-145577979-d97e955b5d8043fd96747447451f78b7.jpg) 
>> Response SVG contains:   <title>This photo contains the following outlines of regions: wall.</title>

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
