### PR TITLE
Handling empty strings in nominatim POI response

### DIFF
--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -459,7 +459,7 @@ def getNodePavingData(POI):
 
 # Checks whether input value is None or empty
 def notNoneorBlank(x):
-    if ((x is not None) and\
+    if ((x is not None) and
             (x.strip() != "")):
         return True
     else:

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -459,8 +459,8 @@ def getNodePavingData(POI):
 
 # Checks whether input value is None or empty
 def notNoneorBlank(x):
-    if ((x is not None) and
-        (x.strip()!= "")):
+    if ((x is not None) and\
+            (x.strip() != "")):
         return True
     else:
         return False

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -209,13 +209,13 @@ def handle():
             longitude = (
                         (float(targetData["lon"]) - lon_min)
                         * scaled_longitude)
-            targetTag = targetData["name"] if ((targetData["name"]\
-                is not None) and (targetData["name"].strip() != ""))\
+            targetTag = targetData["name"] if ((targetData["name"]
+                                                is not None) and (targetData["name"].strip() != ""))\
                 else targetData["display_name"]\
-                if ((targetData["display_name"]\
-                is not None) and\
-                (targetData["display_name"].strip() != ""))\
-                else targetData["type"]
+                if ((targetData["display_name"]
+                     is not None) and
+                    (targetData["display_name"].strip() != ""))\
+                    else targetData["type"]
             if type(targetTag) is not str:
                 raise TypeError
             if targetTag.strip() == "":

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -210,7 +210,8 @@ def handle():
                         (float(targetData["lon"]) - lon_min)
                         * scaled_longitude)
             targetTag = targetData["name"] if ((targetData["name"]
-                                                is not None) and (targetData["name"].strip() != ""))\
+                                                is not None) and 
+                                               (targetData["name"].strip() != ""))\
                 else targetData["display_name"]\
                 if ((targetData["display_name"]
                      is not None) and

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -209,19 +209,18 @@ def handle():
             longitude = (
                         (float(targetData["lon"]) - lon_min)
                         * scaled_longitude)
-            targetTag = targetData["name"] if ((targetData["name"]
-                                                is not None) and
-                                               (targetData["name"].strip()
-                                                != ""))\
+            targetTag = targetData["name"] if\
+                (notNoneorBlank(targetData["name"]))\
                 else targetData["display_name"]\
-                if ((targetData["display_name"]
-                     is not None) and
-                    (targetData["display_name"].strip() != ""))\
+                if (notNoneorBlank(targetData["display_name"]))\
                 else targetData["type"]
             if type(targetTag) is not str:
-                raise TypeError
+                raise TypeError("Type Error. Obtained " +
+                                "variable of type " + str(type(targetTag)))
             if targetTag.strip() == "":
-                raise ValueError
+                raise ValueError("Value Error. Obtained "
+                                 "empty or blank string:"
+                                 "'"+targetTag+"'")
             # Drawing a circle at point of interest if location tag is found
             svg.append(
                         draw.Circle(
@@ -270,14 +269,11 @@ def handle():
             logging.debug("Missing key " + str(e)
                           + " in nominatim preprocessor")
             logging.debug("Reverse geocode data not added to response")
-        except TypeError:
-            logging.debug("Expected to obtain string as "
-                          "POI name in nominatim ")
-            logging.debug("Obtained type " + str(type(targetTag)))
-        except ValueError:
-            logging.debug("Expected to obtain string as "
-                          "POI name in nominatim ")
-            logging.debug("Obtained empty string instead")
+        except (TypeError, ValueError) as e:
+            logging.debug("Did not obtain expected value as "
+                          "POI name in nominatim")
+            logging.debug(str(e))
+            logging.debug("Reverse geocode data not added to response")
 
     # Drawing in the nodes of category
     # intersection, traffic lights or crossing
@@ -459,6 +455,15 @@ def getNodePavingData(POI):
         case _:
             pass
     return (tag if len(tag) == 0 else tag[:-2])
+
+
+# Checks whether input value is None or empty
+def notNoneorBlank(x):
+    if ((x is not None) and
+        (x.strip()!= "")):
+        return True
+    else:
+        return False
 
 
 if __name__ == "__main__":

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -210,13 +210,14 @@ def handle():
                         (float(targetData["lon"]) - lon_min)
                         * scaled_longitude)
             targetTag = targetData["name"] if ((targetData["name"]
-                                                is not None) and 
-                                               (targetData["name"].strip() != ""))\
+                                                is not None) and
+                                               (targetData["name"].strip()
+                                                != ""))\
                 else targetData["display_name"]\
                 if ((targetData["display_name"]
                      is not None) and
                     (targetData["display_name"].strip() != ""))\
-                    else targetData["type"]
+                else targetData["type"]
             if type(targetTag) is not str:
                 raise TypeError
             if targetTag.strip() == "":


### PR DESCRIPTION
Nominatim now returns empty strings instead of 'null' when no tag exists for a latitude-longitude coordinate pair (unlike what was observed the first time #705 was opened!). Closes #705 again ...

As a result if this new behaviour, the check put in for this in the map-tactile-svg handler fails and the resulting description field is: "description":"Tactile rendering of map centered at " (The new 'title' node also contains "map centered at ")

Changes made to use _display_name_ when _name_ is null OR empty and _type_ in case both _name_ and _display_name_ are null. Changes also included to indicate when an empty string is encountered for _type_ in the debug log. In this scenario, the description returned is "Tactile rendering of map centered at latitude {lat} and longitude {long}".

Tested for:
1.  {"latitude": 45, "longitude": -73} for either "" or null in name field

> Resulting description: "Tactile rendering of map centered at 4983, Gore Road, Highgate Center, Highgate, Franklin County, Vermont, 05459, United States" (i.e. the display_name)

2.  {"latitude": 45, "longitude": -73} for either "" and null in name and display_name field
> Resulting description: "description":"Tactile rendering of map centered at house" (i.e. the type)

3. {"latitude": 45, "longitude": -73} for either "" or null in name, display_name and type field
> Resulting description: "description":"Tactile rendering of map centered at latitude 45 and longitude -73" 

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
