### PR TITLE
Fixing the object tag incorrectly pluralized by #759

### DIFF
--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -162,6 +162,8 @@ def handle():
             layer += 1
             g = draw.Group(data_image_layer="Layer " +
                            str(layer), aria_label=category)
+            # Loop through the individual items
+            # Draw a rectangle for each and tag objects 
             for i, id in enumerate(ids):
                 x1 = objects[id]['dimensions'][0] * dimensions[0]
                 x2 = objects[id]['dimensions'][2] * dimensions[0]

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -163,7 +163,7 @@ def handle():
             g = draw.Group(data_image_layer="Layer " +
                            str(layer), aria_label=category)
             # Loop through the individual items
-            # Draw a rectangle for each and tag objects 
+            # Draw a rectangle for each and tag objects
             for i, id in enumerate(ids):
                 x1 = objects[id]['dimensions'][0] * dimensions[0]
                 x2 = objects[id]['dimensions'][2] * dimensions[0]

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -155,8 +155,9 @@ def handle():
         # Loop through the object groups and generate a layer for each
         for group in grouped:
             ids = group["IDs"]
+            obj_tag = objects[ids[0]]["type"]
             # Pluralize names of layers with more than 1 object
-            category = form.plural(objects[ids[0]]["type"]).strip()
+            category = form.plural(obj_tag).strip()
             obj_list.append(str(len(ids)) + " " + category)
             layer += 1
             g = draw.Group(data_image_layer="Layer " +
@@ -178,7 +179,7 @@ def handle():
                         stroke="#ff4477",
                         stroke_width=2.5,
                         fill="none",
-                        aria_label=category+" "+str(i+1)))
+                        aria_label= obj_tag+" "+str(i+1)))
 
             svg.append(g)
 

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -179,7 +179,7 @@ def handle():
                         stroke="#ff4477",
                         stroke_width=2.5,
                         fill="none",
-                        aria_label= obj_tag+" "+str(i+1)))
+                        aria_label=obj_tag+" "+str(i+1)))
 
             svg.append(g)
 


### PR DESCRIPTION
Fixing bug caused by changes made in PR #759 : Both layer names and object tags were pluralized with the earlier change. In the case of a photo with multiple people, the layer tag was set to be people and the object tags were also set to be 'people 1', 'people 2' etc.
Changes have been made to make the object tags singular. (The pluralized layer tags are retained.)

Testing:
1. 
![pexels-johannes-plenio-1126384](https://github.com/Shared-Reality-Lab/IMAGE-server/assets/53469681/416d4047-eaca-4b00-aee7-ffefcb6fc605)
Layer tag: Birds; Object Tags: Bird 1, Bird 2 etc.

2. 
![pexels-christina-morillo-1181605](https://github.com/Shared-Reality-Lab/IMAGE-server/assets/53469681/78711aa0-b91c-4e59-8bb3-16b52107eae3)
Layer Tag: People; Object Tags: Person 1, Person 2

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
* [x] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
