### PR TITLE
Add settable PREPROCESSOR_TIMEOUT env var

### DIFF
--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -35,7 +35,7 @@ const ajv = new Ajv2020({
     "schemas": [definitionsJSON, querySchemaJSON, responseSchemaJSON, handlerResponseSchemaJSON, preprocessorResponseSchemaJSON]
 });
 
-const PREPROCESSOR_TIME_MS = 15000;
+const PREPROCESSOR_TIME_MS = (!isNaN(parseInt(process.env.PREPROCESSOR_TIMEOUT || ""))) ? parseInt(process.env.PREPROCESSOR_TIMEOUT || "") : 15000;
 
 const BASE_LOG_PATH = path.join("/var", "log", "IMAGE");
 


### PR DESCRIPTION
Resolve #775 by adding the `PREPROCESSOR_TIMEOUT` variable which takes the group/individual preprocessor timeout in milliseconds. Defaults to 15 s if not specified. Tested on unicorn by running with it unset (resulting in normal behaviour) and set to 10 (resulting in all preprocessors failing to return and connections being aborted).

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
