### PR TITLE
Allow variable delay between pings

### DIFF
--- a/services/supercollider-images/supercollider-service/charts/line.scd
+++ b/services/supercollider-images/supercollider-service/charts/line.scd
@@ -17,7 +17,7 @@
 var singleLineChart;
 "Single Line Chart".postln;
 singleLineChart = { |json, ttsData, outPath, addr|
-    var score, timing, order=5, baseGain=(-4.dbamp), audio, seriesData, miny, maxy;
+    var score, timing, order=5, baseGain=(-4.dbamp), audio, seriesData, miny, maxy, timediff;
     timing = 0;
     score = IMAGE.newScore(order);
     // Set up b-format decoder
@@ -62,6 +62,10 @@ singleLineChart = { |json, ttsData, outPath, addr|
     });
     miny = seriesData.flop[1].minItem;
     maxy = seriesData.flop[1].maxItem;
+    // Below defines a band where rendering duration will not increase
+    // but instead the time between pings will get shorter, sounding
+    // continuous to the listener. This may need to be adjusted further.
+    timediff = seriesData.size.linlin(20, 1000, 0.1, 0.001);
     seriesData.do({ |item, i|
         score.add([
             timing,
@@ -75,7 +79,7 @@ singleLineChart = { |json, ttsData, outPath, addr|
                 \gain, baseGain * 0.1
             ]
         ]);
-        timing = timing + 0.002;
+        timing = timing + timediff;
     });
     timing = timing + 0.1;
     score.add([timing, [0]]);


### PR DESCRIPTION
This is meant to support small and large numbers of points in a rendered dataset. For smaller values, discrete pings will be heard. As sizes grow, it will sound continuous. Note that the overall size of the rendering will only begin increasing after 1000 points, and this may need to be revised down (with ping delay markers adjusted) depending on encountered examples.

Tested on unicorn with the problematic etherscan graphic.

Resolves #842.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
