### PR TITLE
Include the Monarch link app as a service on IMAGE-server

### DIFF
--- a/services/monarch-link-app/Dockerfile
+++ b/services/monarch-link-app/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10
+
+RUN apt-get install libcairo2
+
+RUN adduser --disabled-password python
+WORKDIR /usr/src/app
+ENV PATH="/home/python/.local/bin:${PATH}"
+
+RUN pip install --upgrade pip
+COPY /services/monarch-link-app/requirements.txt /usr/src/app/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY /services/monarch-link-app/ /usr/src/app
+
+EXPOSE 80
+USER python
+CMD ["gunicorn", "app:app", "-b", "0.0.0.0:80", "--capture-output", "--log-level=debug" ]

--- a/services/monarch-link-app/Dockerfile
+++ b/services/monarch-link-app/Dockerfile
@@ -12,6 +12,8 @@ RUN pip install -r requirements.txt
 
 COPY /services/monarch-link-app/ /usr/src/app
 
+RUN chown -R python:python /usr/src/app
+
 EXPOSE 80
 USER python
 CMD ["gunicorn", "app:app", "-b", "0.0.0.0:80", "--capture-output", "--log-level=debug" ]

--- a/services/monarch-link-app/README.md
+++ b/services/monarch-link-app/README.md
@@ -1,0 +1,1 @@
+This is the app used to connect IMAGE-TactileAuthoring to IMAGE-Monarch. 

--- a/services/monarch-link-app/app.py
+++ b/services/monarch-link-app/app.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 
 app = Flask(__name__)
-app.config.from_pyfile('config.py')
 logging.basicConfig(level=logging.DEBUG)
 
 CORS(

--- a/services/monarch-link-app/app.py
+++ b/services/monarch-link-app/app.py
@@ -1,0 +1,71 @@
+from flask import Flask, request, jsonify, abort, Response
+from flask_cors import CORS, cross_origin
+import logging
+import hashlib
+import json
+
+app = Flask(__name__)
+app.config.from_pyfile('config.py')
+logging.basicConfig(level=logging.DEBUG)
+
+CORS(
+    app, resources={r"/*": {"origins": "*"}}
+)  # CORS allowed for all domains on all routes
+
+try:
+    with open("data.json", 'x') as file:
+        json.dump(dict(), file)
+except FileExistsError:
+    logging.debug("The file already exists")
+
+def write_data(svgData):
+    with open("data.json", "w") as outfile:
+        json.dump(svgData, outfile)
+
+def read_data():
+    with open('data.json', 'r') as openfile:
+        try:
+            return json.load(openfile)
+        except Exception:
+            return dict()
+
+@app.route("/create/<id>", methods=["POST"])
+@cross_origin()
+def render(id):
+    if request.method=="POST":
+        req_data=request.get_json()
+        svgData = read_data()
+        if id in svgData:
+            if (svgData[id])["secret"] == req_data["secret"]:
+                svgData[id] = {"secret":req_data["secret"], "data": req_data["data"], "layer": req_data["layer"]}
+                write_data(svgData)
+                return jsonify("Graphic in channel "+id+" has been updated!")
+            else:
+                return jsonify("Unauthorized access to existing channel!")
+        else:
+            svgData[id] = {"secret":req_data["secret"], "data": req_data["data"], "layer": req_data["layer"]}
+            write_data(svgData)
+            return jsonify("New channel created with code "+id)
+
+@app.route("/display/<id>", methods=["GET"])
+@cross_origin()
+def display(id):
+    if request.method=="GET":
+        svgData = read_data()
+        if id in svgData:
+            response= Response()
+            response.mimetype = "application/json"
+            response.set_data(json.dumps({"renderings":[{"data":{"graphic":svgData[id]["data"], "layer": svgData[id]["layer"]}}]}))
+            response.add_etag(hashlib.md5((svgData[id]["data"]+svgData[id]["layer"]).encode()))
+            response.make_conditional(request)
+            return response
+        else:
+            return abort(404)
+
+@app.route("/", methods=["POST", "GET"])
+@cross_origin()
+def home():
+    return "Hi"
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=80, debug=True)

--- a/services/monarch-link-app/requirements.txt
+++ b/services/monarch-link-app/requirements.txt
@@ -12,3 +12,4 @@ six==1.16.0
 SQLAlchemy==1.4.43
 SQLAlchemy-Utils==0.38.3
 Werkzeug==2.2.2
+gunicorn==22.0.0

--- a/services/monarch-link-app/requirements.txt
+++ b/services/monarch-link-app/requirements.txt
@@ -1,0 +1,14 @@
+click==8.1.3
+colorama==0.4.6
+Flask==2.2.2
+Flask-Cors==4.0.2
+Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.2
+greenlet==2.0.1
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.1
+six==1.16.0
+SQLAlchemy==1.4.43
+SQLAlchemy-Utils==0.38.3
+Werkzeug==2.2.2


### PR DESCRIPTION
This PR merges a containerized version of the Monarch web application that links the [IMAGE-TactileAuthoring](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring) tool to the [Monarch client](https://github.com/Shared-Reality-Lab/IMAGE-Monarch). 

As per [discussions](https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/392), this application has been made into a service on the IMAGE-server. It can be accessed by the Monarch client at https://monarch.unicorn.cim.mcgill.ca/display/<subscribed_code>. Resolves #888.

Testing:

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
