### PR TITLE
Add support for "route" feature to orchestrator

### DIFF
--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -128,7 +128,7 @@ async function runPreprocessorsParallel(data: Record<string, unknown>, preproces
                         if(response.status == 200){
                             response.json().then((json) => {
                                 if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", json)) {
-                                    // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP    
+                                    // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP
                                     SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = json["name"];
                                     // store data in cache
                                     // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
@@ -200,7 +200,7 @@ async function runPreprocessors(data: Record<string, unknown>, preprocessors: (s
                 console.error(err);
                 continue;
             }
-    
+
             // OK data returned
             if (resp.status === 200) {
                 try {


### PR DESCRIPTION
Resolves #889 by adding support for the `ca.mcgill.a11y.image.route` label on preprocessors and handlers and using the `route` field in the request, when available. Tested with the `/render` and `/render/preprocess` endpoints.

Also tested with unset (default) route label values, single route label values, and multiple route label values. Follows the flowchart below, with less information on a failed regexp check since getting information on *why* it failed requires a slower command.

![route-flow](https://github.com/user-attachments/assets/eaa8127c-1073-45ec-859f-1081f9abdf67)

* the `inPartOfRoute` function checks if a service's label (if set) includes the key specified in the request (or the default label). This function is used in the filtering code for identifying preprocessors and handlers to call.
  * `route` is added as a parameter to `getPreprocessorServices` and `getHandlerServices` to facilitate this.
* Add `getRoute` function to extract the `route` function from the request. Called in both `/render` and `/render/preprocess`.

Note that because preprocessors and handlers are filtered out *before* we begin sending requests, this builds upon the existing caching system.

Assigning @jaydeepsingh25 and @jeffbl. @VenissaCarolQuadros ping so you were asking about these changes.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
