### PR TITLE
Return valid osm response for placeId

### DIFF
--- a/preprocessors/ner/requirements.txt
+++ b/preprocessors/ner/requirements.txt
@@ -7,7 +7,7 @@ torch==1.13.1
 tqdm~=4.66.3
 torchvision==0.8.2
 clip-by-openai==1.1
-scikit-learn==1.5.0
+scikit-learn==1.1.2
 packaging==21.3
 jsonschema==3.2.0
 Flask==2.2.5


### PR DESCRIPTION
The PR provides fix for https://github.com/Shared-Reality-Lab/IMAGE-server/issues/870.
It fixes a common bug for the cases where map request is made with a query text, OSM preprocessor does not return a valid response in that case. 
PlaceId in the request in the request contains the queryText and not actual placeId. Hence we need to call `place/textsearch `endpoint rather than `place/details` endpoint. Autour preprocess has a similar logic in place.
Tested on unicorn with both the cases(coordinates and placeId)

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
