### PR TITLE
Populate title from graphic-caption when present

### DIFF
--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -254,23 +254,24 @@ def handle():
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
 
-        # Checking if graphic-caption preprocessor is present
-        if ("ca.mcgill.a11y.image.preprocessor.graphic-caption"
-                in preprocessors):
-            logging.debug("Adding title from "
-                          "graphic-caption")
-            caption = preprocessors["ca.mcgill.a11y.image."
-                                    "preprocessor.graphic-caption"][
-                              "caption"]
-        else:
-            logging.debug("graphic-caption not found. "
-                          "Adding default title.")
-            if len(obj_list) > 0:
-                if len(obj_list) > 1:
-                    obj_list[-1] = "and " + obj_list[-1] + "."
-                    caption += ", ".join(obj_list)
-                else:
-                    caption += obj_list[0] + "."
+        if len(obj_list) > 0:
+            if len(obj_list) > 1:
+                obj_list[-1] = "and " + obj_list[-1] + "."
+                caption += ", ".join(obj_list)
+            else:
+                caption += obj_list[0] + "."
+
+    # Checking if graphic-caption preprocessor is present
+    if ("ca.mcgill.a11y.image.preprocessor.graphic-caption"
+            in preprocessors):
+        logging.debug("Adding title from "
+                      "graphic-caption")
+        caption = preprocessors["ca.mcgill.a11y.image."
+                                "preprocessor.graphic-caption"][
+                            "caption"]
+    else:
+        logging.debug("graphic-caption not found. "
+                      "Adding default title.")
 
     title = draw.Title(caption)
     svg.append(title)

--- a/handlers/photo-tactile-svg/tactile_svg.py
+++ b/handlers/photo-tactile-svg/tactile_svg.py
@@ -254,12 +254,23 @@ def handle():
                             dimensions[1] - coords[i][1] * dimensions[1])
                 svg.append(p)
 
-        if len(obj_list) > 0:
-            if len(obj_list) > 1:
-                obj_list[-1] = "and " + obj_list[-1] + "."
-                caption += ", ".join(obj_list)
-            else:
-                caption += obj_list[0] + "."
+        # Checking if graphic-caption preprocessor is present
+        if ("ca.mcgill.a11y.image.preprocessor.graphic-caption"
+                in preprocessors):
+            logging.debug("Adding title from "
+                          "graphic-caption")
+            caption = preprocessors["ca.mcgill.a11y.image."
+                                    "preprocessor.graphic-caption"][
+                              "caption"]
+        else:
+            logging.debug("graphic-caption not found. "
+                          "Adding default title.")
+            if len(obj_list) > 0:
+                if len(obj_list) > 1:
+                    obj_list[-1] = "and " + obj_list[-1] + "."
+                    caption += ", ".join(obj_list)
+                else:
+                    caption += obj_list[0] + "."
 
     title = draw.Title(caption)
     svg.append(title)


### PR DESCRIPTION
Changes have been made to the photo-tactile-svg handler to incorporate the response from the graphic-caption preprocessor in the title field. When no response is received from the graphic-caption preprocessor, the title field defaults to the objects and outlines of regions found by the object detection and semantic segmentation preprocessor. Closes #908.

Tested for ![Three cows image](https://github.com/user-attachments/assets/0344e83b-ce1d-4a13-b285-754dda755a1e)

The SVG with graphic-caption:
```
<svg>
...
<title> The image is a photograph featuring three cows, two of which are closer to the viewer, looking towards them with focused expressions, while the third cow in the background appears smaller and less detailed, against a clear blue sky. </title>
</svg>
```

The SVG without graphic-caption: 
```
<svg>
...
<title>This photo contains 3 cows.This photo also contains the following outlines of regions: animal, sky, and tree.</title>
</svg>
```

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8])
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
