### PR TITLE
check if the category of the graphic is a photograph

### DIFF
--- a/preprocessors/depth-map-gen/depth-map-generator.py
+++ b/preprocessors/depth-map-gen/depth-map-generator.py
@@ -109,10 +109,25 @@ def depthgenerator():
     except jsonschema.exceptions.ValidationError as e:
         logging.error(e)
         return jsonify("Invalid Preprocessor JSON format"), 400
+    
+    # check content category from contentCategoriser
+    preprocess_output = content.get("preprocessors", {})
+    classifier_1 = "ca.mcgill.a11y.image.preprocessor.contentCategoriser"
+    if classifier_1 in preprocess_output:
+        classifier_1_output = preprocess_output[classifier_1]
+        classifier_1_label = classifier_1_output.get("category", "")
+        if classifier_1_label != "photograph":
+            logging.info("Not photograph content. Skipping...")
+            return "", 204
+    else:
+        logging.info("Content categorizer output missing. Skipping...")
+        return "", 204
+    
     # check for image
     if "graphic" not in content:
         logging.info("Request is not a graphic. Skipping...")
         return "", 204  # No content
+    
     request_uuid = content["request_uuid"]
     timestamp = time.time()
     name = "ca.mcgill.a11y.image.preprocessor.depth-map-gen"


### PR DESCRIPTION
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [X] I described the changes made and how these address the issue. --> -> added a validation step to check the category of the graphic using the content categorizer preprocessor, like semantic segmentation. If the category is not "photograph", the preprocessor skips processing and returns a 204, No Content response
- [X] I described how I tested these changes. --> 

tested with images on https://image.a11y.mcgill.ca/
depth-map-generator-1  | [2024-11-18 02:52:37 +0000] [7] [DEBUG] POST /preprocessor
depth-map-generator-1  | DEBUG:root:Received request
depth-map-generator-1  | DEBUG:root:Sending response

whereas on a charts
1.
![image](https://github.com/user-attachments/assets/7ef87a38-96c3-483f-938c-ebe2cf9d5727)
2. 
![image](https://github.com/user-attachments/assets/e90d9454-7b1e-4fe9-ae94-6b297b4a522c)
3. 
![image](https://github.com/user-attachments/assets/3a5483e5-fd20-4b9e-9668-b77d5d1746a6)

the output was as follows:
depth-map-generator-1  | [2024-11-18 02:53:51 +0000] [7] [DEBUG] POST /preprocessor
depth-map-generator-1  | DEBUG:root:Received request
depth-map-generator-1  | INFO:root:Not photograph content. Skipping...

depth-map-generator-1  | [2024-11-18 02:59:20 +0000] [7] [DEBUG] POST /preprocessor
depth-map-generator-1  | DEBUG:root:Received request
depth-map-generator-1  | INFO:root:Content categorizer output missing. Skipping...

depth-map-generator-1  | [2024-11-18 02:59:53 +0000] [7] [DEBUG] POST /preprocessor
depth-map-generator-1  | DEBUG:root:Received request
depth-map-generator-1  | INFO:root:Not photograph content. Skipping...


## Coding/Commit Requirements

* [X] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [X] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [X] I have not added a new component in this PR.
