### PR TITLE
Categoriser llama3.2

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -85,7 +85,7 @@ def categorise():
         logging.warn("OLLAMA_API_KEY usually starts with sk-, "
                      "but this one starts with: " + api_key[:3])
 
-    prompt = "Answer with only one word. " \
+    prompt = "Answer with only one word, and without punctuation. " \
              "Which of the following categories best describes this photo? "
     possible_categories = "photograph, chart, text, other"
 


### PR DESCRIPTION
resolves #922

This PR reworks content-categoriser to use llama3.2-vision instead of llava for the LMM. Notes:
- error handling is completely reworked, and returns 204 rather than 500 when the LLM messes up and returns useless results
- results are requested in JSON rather than just a single word, to further constrain the model.
- Note that the ollama.env config file needs to be set to pegasus, since llama3.2-vision is too big for unicorn. This is how it is currently set on unicorn.
- Limited testing of updated prompts was done against llava, in case we ever want to switch back. This will probably take some tweaking, and it may not be as good at making outputs in JSON-only.
- llama3.2 seems slower than llava, taking about 1.5s based on log output (when querying pegasus), but more timing work should be done once timing is working again in the orchestrator. It is a larger model, but perhaps we can find ways to speed this up.
- Note #923 is a remaining issue, with GIF files not working at all. This should be fixed before moving to production.

Testing included the graphics from #874, and ad-hoc additional graphics. Simulation of bad results from the LLM were artificially inserted directly in the code to test error pathways.

TODO: There is a TypeError exception that should be further investigated, but I don't think it will have any impact on end-user results, just what we might want to output into the log to know why it happened.

TODO: There should be a way to not only ask for JSON in the prompt, but also send a model parameter that specifies this as well. It doesn't work, so I've commented it out and marked it as TODO in the code. That said, I have had few problems with llama3.2-vision refusing to answer in JSON, but I'm sure we'll come across something.


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
