### PR TITLE
Save source graphic in monarch-link-app and clear unused entries periodically

### DIFF
--- a/services/monarch-link-app/Dockerfile
+++ b/services/monarch-link-app/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.13
+FROM python:3.11-alpine3.20
 
-RUN apt-get install libcairo2
+RUN apk add supercronic
 
 RUN adduser --disabled-password python
 WORKDIR /usr/src/app
@@ -16,4 +16,5 @@ RUN chown -R python:python /usr/src/app
 
 EXPOSE 80
 USER python
-CMD ["gunicorn", "app:app", "-b", "0.0.0.0:80", "--capture-output", "--log-level=debug" ]
+CMD supercronic -quiet /usr/src/app/cronjob \
+    & gunicorn app:app -b 0.0.0.0:80 --capture-output --log-level=debug

--- a/services/monarch-link-app/app.py
+++ b/services/monarch-link-app/app.py
@@ -17,6 +17,7 @@
 from flask import Flask, request, abort, Response
 from flask_bcrypt import Bcrypt
 from flask_cors import CORS, cross_origin
+from datetime import datetime
 import logging
 import hashlib
 import json
@@ -96,7 +97,8 @@ def create():
                            .decode('utf-8'),
                            "data": req_data["data"],
                            "title": req_data["title"],
-                           "layer": req_data["layer"]}
+                           "layer": req_data["layer"],
+                           "timestamp": datetime.timestamp(datetime.now())}
             # include source graphic if present
             if "graphicBlob" in req_data:
                 svgData[id]["graphicBlob"] = req_data["graphicBlob"]
@@ -127,7 +129,9 @@ def update(id):
                                     req_data["secret"]).decode('utf-8'),
                                    "data": req_data["data"],
                                    "title": req_data["title"],
-                                   "layer": req_data["layer"]}
+                                   "layer": req_data["layer"],
+                                   "timestamp": datetime.timestamp(
+                                       datetime.now())}
                     # include source graphic if present
                     if "graphicBlob" in req_data:
                         svgData[id]["graphicBlob"] = req_data["graphicBlob"]
@@ -143,7 +147,11 @@ def update(id):
                                 req_data["secret"]).decode('utf-8'),
                                "data": req_data["data"],
                                "title": req_data["title"],
-                               "layer": req_data["layer"]}
+                               "layer": req_data["layer"],
+                               "timestamp": datetime.timestamp(datetime.now())}
+                # include source graphic if present
+                if "graphicBlob" in req_data:
+                    svgData[id]["graphicBlob"] = req_data["graphicBlob"]
                 write_data(svgData)
                 logging.debug('TEMP: Created new channel using update!')
                 return ("New channel created with code "+id +

--- a/services/monarch-link-app/app.py
+++ b/services/monarch-link-app/app.py
@@ -97,6 +97,9 @@ def create():
                            "data": req_data["data"],
                            "title": req_data["title"],
                            "layer": req_data["layer"]}
+            # include source graphic if present
+            if "graphicBlob" in req_data:
+                svgData[id]["graphicBlob"] = req_data["graphicBlob"]
             write_data(svgData)
             logging.debug('Created new channel with code '+id)
             return {"id": id, "secret": secret}
@@ -125,6 +128,9 @@ def update(id):
                                    "data": req_data["data"],
                                    "title": req_data["title"],
                                    "layer": req_data["layer"]}
+                    # include source graphic if present
+                    if "graphicBlob" in req_data:
+                        svgData[id]["graphicBlob"] = req_data["graphicBlob"]
                     write_data(svgData)
                     logging.debug('Updated graphic')
                     return "Graphic in channel "+id+" has been updated!"
@@ -161,9 +167,12 @@ def display(id):
             try:
                 response = Response()
                 response.mimetype = "application/json"
-                response.set_data(json.dumps({"renderings": [
+                response_val = {"renderings": [
                                 {"data": {"graphic": svgData[id]["data"],
-                                          "layer": svgData[id]["layer"]}}]}))
+                                          "layer": svgData[id]["layer"]}}]}
+                if "graphicBlob" in svgData[id]:
+                    response_val["graphicBlob"] = svgData[id]["graphicBlob"]
+                response.set_data(json.dumps(response_val))
                 response.add_etag(hashlib.md5(
                     (svgData[id]["data"]+svgData[id]["layer"]).encode()))
                 response.make_conditional(request)

--- a/services/monarch-link-app/clean_up.py
+++ b/services/monarch-link-app/clean_up.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import json
+from datetime import datetime
+import logging
+
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.DEBUG,
+    datefmt='%Y-%m-%d %H:%M:%S')
+
+
+def clean_up(data):
+    cleaned = {}
+    for id in data:
+        # last update timestamp is more than 3600 seconds
+        # before current timestamp
+        if not float(data[id]["timestamp"]) + 3600 < (
+                datetime.timestamp(datetime.now())):
+            cleaned[id] = data[id]
+        else:
+            logging.debug('Cleared ID value: '+id)
+    return cleaned
+
+
+try:
+    with open('/usr/src/app/data.json', 'r') as openfile:
+        # Load the JSON data
+        data = json.load(openfile)
+
+    # Process and write cleaned data
+    cleaned_data = clean_up(data)
+    with open('/usr/src/app/data.json', 'w') as openfile:
+        json.dump(cleaned_data, openfile)
+except Exception as e:
+    logging.debug(e)

--- a/services/monarch-link-app/cronjob
+++ b/services/monarch-link-app/cronjob
@@ -1,0 +1,1 @@
+*/10 * * * * python3 /usr/src/app/clean_up.py >> /usr/src/app/cron.log 2>&1

--- a/services/monarch-link-app/cronjob
+++ b/services/monarch-link-app/cronjob
@@ -1,1 +1,1 @@
-*/10 * * * * python3 /usr/src/app/clean_up.py >> /usr/src/app/cron.log 2>&1
+*/10 * * * * python3 /usr/src/app/clean_up.py >> /proc/1/fd/1 2>&1


### PR DESCRIPTION
Changes made to the monarch-link-app are as follows:
1. The monarch-link-app accepts an optional additional field 'graphicBlob', the source graphic. This is required for a client receiving graphics published by the [TAT](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring/) or the [extension](https://github.com/Shared-Reality-Lab/IMAGE-browser) to make follow up queries.
2. A cron job has been included to clear unused entries after 60 minutes. This change is required to avoid storing IDs indefinitely and unnecessarily using too much storage on the server. The flask app has been modified to include a timestamp field to identify last updated time and the script run by the cron job uses this to identify if the entry is actively being used. 

This PR involves changes required for Shared-Reality-Lab/IMAGE-browser#391 and moving the monarch-link-app to production

1. Testing changes to include 'graphicBlob' field:
Tested with post requests to /create and /update/\<id\> endpoints with and without "graphicBlob" field:
The resulting display/\<id\>  with "graphicBlob" and without "graphicBlob" were as follows:

- With "graphicBlob":
```
{
  "renderings": [
    {
      "data": {
        "graphic": "Testing data",
        "layer": "None"
      }
    }
  ],
  "graphicBlob": "Testing source graphic"
}
```
- Without "graphicBlob":
```
{
  "renderings": [
    {
      "data": {
        "graphic": "Testing data",
        "layer": "None"
      }
    }
  ]
}
```
i.e. the results were identical except for the presence of graphicBlob in /display/\<id\> response when it was present in the entry
2. Testing cron job:
Logs from monarch-link-app:
```
[2024-12-13 17:51:33 +0000] [15] [DEBUG] POST /create
DEBUG:root:Create request received
DEBUG:root:Created new channel with code 543647
[2024-12-13 17:52:39 +0000] [15] [DEBUG] GET /display/543647
DEBUG:root:Display request received
DEBUG:root:Sending tactile response
[2024-12-13 18:07:26 +0000] [15] [DEBUG] OPTIONS /create
[2024-12-13 18:07:26 +0000] [15] [DEBUG] POST /create
DEBUG:root:Create request received
DEBUG:root:Created new channel with code 156528
[2024-12-13 18:52:55 +0000] [15] [DEBUG] OPTIONS /update/156528
[2024-12-13 18:52:55 +0000] [15] [DEBUG] POST /update/156528
DEBUG:root:Update request received
DEBUG:root:Updated graphic
```
Logs from cron job:
```
2024-12-13 19:00:00 DEBUG    Cleared ID value: 543647
2024-12-13 20:00:00 DEBUG    Cleared ID value: 156528
```
Entry with code 543647 was deleted at 19:00:00 i.e. about an hour after it was created. Entry with code 156528 was deleted at 20:00:00 i.e. roughly an hour after it was last updated although it was created at 18:07:26. 


---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
