### PR TITLE
measureExecutionTime logging bug - function wrapping the entire request-response lifecycle for each preprocessor

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as builder
+FROM node:alpine AS builder
 
 
 WORKDIR /usr/src/app
@@ -8,7 +8,7 @@ COPY orchestrator/src ./src
 COPY schemas src/schemas
 RUN npm run build && npm prune --production
 
-FROM node:alpine as final
+FROM node:alpine AS final
 
 RUN apk add memcached
 # Set up for logging

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -85,105 +85,100 @@ async function measureExecutionTime<T>(label:string, fn: () => Promise<T>): Prom
     }
 }
 
-async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
+async function executePreprocessor(preprocessor: (string | number)[],data: Record<string, unknown>): Promise<void> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+        controller.abort();
+    }, PREPROCESSOR_TIME_MS);
+    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
+    const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
+    // get value from cache for each preprocessor if it exists
+    const cacheTimeOut = preprocessor[3] as number;
+  
+    try {
+      await measureExecutionTime(`Preprocessor "${preprocessor[0]}"`, async () => {
+        // check cache first
+        const cacheValue = await serverCache.getResponseFromCache(hashedKey);
+        if (cacheTimeOut > 0 && cacheValue && preprocessorName) {
+            // Return the value from cache if found
+            console.debug(`Response for preprocessor ${preprocessorName} served from cache`);
+            const cacheResponse = JSON.parse(cacheValue) as Response;
+            (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = cacheResponse;
+            return; // skip fetch if cache is valid
+        }
+  
+        // fetch from the preprocessor
+        const response = await fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+            signal: controller.signal,
+        });
+  
+        clearTimeout(timeout);
+  
+        // Process the response
+        if (response.status === 200) {
+          const jsonResponse = await response.json();
+          if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", jsonResponse)) {
+            (data["preprocessors"] as Record<string, unknown>)[jsonResponse["name"]] = jsonResponse["data"];
+            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP
+            SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = jsonResponse["name"];
+            // store data in cache
+            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
+            if (cacheTimeOut > 0) {
+                console.debug(`Saving Response for ${jsonResponse["name"]} in cache with key ${hashedKey}`);
+                await serverCache.setResponseInCache(hashedKey, JSON.stringify(jsonResponse["data"]), cacheTimeOut);
+            }
+          } else {
+            console.error("Preprocessor response failed validation!");
+            console.error(JSON.stringify(ajv.errors));
+          }
+        } else if (response.status === 204) {
+          console.debug(`Preprocessor "${preprocessor[0]}" not applicable`);
+          return;
+        } else {
+          console.error(`Preprocessor "${preprocessor[0]}" responded with status ${response.status}`);
+        }
+      });
+    } catch (err) {
+      console.error(`Error occurred fetching from preprocessor "${preprocessor[0]}"`);
+      console.error(err);
+    }
+  }
+  
+  async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {
         data["preprocessors"] = {};
     }
-
     let currentPriorityGroup: number | undefined = undefined;
     let promises: Promise<Response | void>[] = [];
-
-    // handles only the promises in the current priority group & resets promises after processsing each group.
+  
     const awaitResponses = async () => {
         await Promise.all(promises);
         promises = [];
     };
-
+  
     for (const preprocessor of preprocessors) {
-        // check if priority group changes - if so, wait for the current promises to finish
         if (preprocessor[2] !== currentPriorityGroup) {
             if (promises.length > 0) {
-                await awaitResponses();
+            await awaitResponses();
             }
             currentPriorityGroup = Number(preprocessor[2]);
-            console.log("Now on priority group " + currentPriorityGroup);
+            console.debug(`Now on priority group ${currentPriorityGroup}`);
         }
-
-        // profile the request -- each preprocessor's entire lifecycle (fetch + response processing) is wrapped in measureExecutionTime
-        const promise = new Promise<void>((resolve) => {
-            // measure the execution time 
-            measureExecutionTime(`Preprocessor "${preprocessor[0]}"`, async () => {
-                const controller = new AbortController();
-                const timeout = setTimeout(() => {
-                    controller.abort();
-                }, PREPROCESSOR_TIME_MS);
-
-                try {
-                    // get value from cache for each preprocessor if it exists
-                    const cacheTimeOut = preprocessor[3] as number;
-                    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
-                    const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
-
-                    const cacheValue = await serverCache.getResponseFromCache(hashedKey);
-
-                    if (cacheTimeOut > 0 && cacheValue && preprocessorName) {
-                        // Return the value from cache if found
-                        console.debug(`Response for preprocessor ${preprocessorName} served from cache`);
-                        const cacheResponse = JSON.parse(cacheValue) as Response;
-                        (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = cacheResponse;
-                        return; // Skip fetch if cache is valid
-                    }
-                    // Call the preprocessor endpoint to get response
-                    console.debug(`Sending to preprocessor "${preprocessor[0]}"`);
-                    const resp = await fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify(data),
-                        signal: controller.signal
-                    });
-
-                    clearTimeout(timeout);
-
-                    // Process the response
-                    if (resp.status === 200) {
-                        const json = await resp.json();
-                        if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", json)) {
-                            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP  
-                            (data["preprocessors"] as Record<string, unknown>)[json["name"]] = json["data"];
-                            SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = json["name"];
-                            // store data in cache
-                            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
-                            if (cacheTimeOut > 0) {
-                                console.debug(`Saving Response for ${json["name"]} in cache with key ${hashedKey}`);
-                                await serverCache.setResponseInCache(hashedKey, JSON.stringify(json["data"]), cacheTimeOut);
-                            }
-                        } else {
-                            console.error("Preprocessor response failed validation!");
-                            console.error(JSON.stringify(ajv.errors));
-                        }
-                    } else if (resp.status === 204) {
-                        // preprocessor not applicable
-                        return;
-                    } else {
-                        console.error(`Preprocessor "${preprocessor[0]}" responded with status ${resp.status}`);
-                    }
-                } catch (err) {
-                    console.error(`Error occurred fetching from ${preprocessor[0]}`);
-                    console.error(err);
-                }
-            }).finally(() => resolve()); // resolve the promise regardless of success or failure
-        }); // end of measureExecutionTime
-
-        promises.push(promise);
+  
+        // add the preprocessor lifecycle as a promise
+        promises.push(executePreprocessor(preprocessor, data));
     }
-
-    //wait for any remaining promises to resolve
+  
     if (promises.length > 0) {
         await awaitResponses();
     }
-
+  
     return data;
-}
+  }
+  
 
 async function runPreprocessors(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -71,14 +71,14 @@ async function measureExecutionTime<T>(label: string, fn: () => Promise<T>): Pro
         return result;
     } finally {
         const endTime = performance.now();
-        const duration = parseFloat((endTime - startTime).toFixed(3)); // wall-clock duration in ms
+        const duration = parseFloat((endTime - startTime).toFixed(2)); // wall-clock duration in ms
         const endCpuUsage = process.cpuUsage(startCpuUsage);
-        const cpuTime = parseFloat(((endCpuUsage.user + endCpuUsage.system) / 1000).toFixed(3)); // CPU time in ms
+        const cpuTime = parseFloat(((endCpuUsage.user + endCpuUsage.system) / 1000).toFixed(2)); // CPU time in ms
         // Normalize CPU Usage as a percentage of wall-clock duration and number of cores -- https://stackoverflow.com/questions/74776323/trying-to-get-normalized-cpu-usage-for-node-process
-        const normalizedCpuUsage = parseFloat(((cpuTime / (duration * coreCount)) * 100).toFixed(3)); // normalized CPU usage
+        const normalizedCpuUsage = parseFloat(((cpuTime / (duration * coreCount)) * 100).toFixed(2)); // normalized CPU usage
 
         console.log(`timestamp=${new Date().toISOString()} label=${label} execution_time_ms=${duration}ms cpu_time_ms=${cpuTime}ms normalized_cpu_usage_percent=${normalizedCpuUsage}%`);
-        // To extract the log into a dictionary --> log_dict = {item.split('=')[0]: item.split('=')[1] for item in log.split(' ')} to store 
+        // To extract the log and store into a dictionary --> log_dict = {item.split('=')[0]: item.split('=')[1] for item in log.split(' ')}  
     }
 }
 

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -85,100 +85,105 @@ async function measureExecutionTime<T>(label:string, fn: () => Promise<T>): Prom
     }
 }
 
-async function executePreprocessor(preprocessor: (string | number)[],data: Record<string, unknown>): Promise<void> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => {
-        controller.abort();
-    }, PREPROCESSOR_TIME_MS);
-    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
-    const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
-    // get value from cache for each preprocessor if it exists
-    const cacheTimeOut = preprocessor[3] as number;
-  
-    try {
-      await measureExecutionTime(`Preprocessor "${preprocessor[0]}"`, async () => {
-        // check cache first
-        const cacheValue = await serverCache.getResponseFromCache(hashedKey);
-        if (cacheTimeOut > 0 && cacheValue && preprocessorName) {
-            // Return the value from cache if found
-            console.debug(`Response for preprocessor ${preprocessorName} served from cache`);
-            const cacheResponse = JSON.parse(cacheValue) as Response;
-            (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = cacheResponse;
-            return; // skip fetch if cache is valid
-        }
-  
-        // fetch from the preprocessor
-        const response = await fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(data),
-            signal: controller.signal,
-        });
-  
-        clearTimeout(timeout);
-  
-        // Process the response
-        if (response.status === 200) {
-          const jsonResponse = await response.json();
-          if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", jsonResponse)) {
-            (data["preprocessors"] as Record<string, unknown>)[jsonResponse["name"]] = jsonResponse["data"];
-            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP
-            SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = jsonResponse["name"];
-            // store data in cache
-            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
-            if (cacheTimeOut > 0) {
-                console.debug(`Saving Response for ${jsonResponse["name"]} in cache with key ${hashedKey}`);
-                await serverCache.setResponseInCache(hashedKey, JSON.stringify(jsonResponse["data"]), cacheTimeOut);
-            }
-          } else {
-            console.error("Preprocessor response failed validation!");
-            console.error(JSON.stringify(ajv.errors));
-          }
-        } else if (response.status === 204) {
-          console.debug(`Preprocessor "${preprocessor[0]}" not applicable`);
-          return;
-        } else {
-          console.error(`Preprocessor "${preprocessor[0]}" responded with status ${response.status}`);
-        }
-      });
-    } catch (err) {
-      console.error(`Error occurred fetching from preprocessor "${preprocessor[0]}"`);
-      console.error(err);
-    }
-  }
-  
-  async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
+async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {
         data["preprocessors"] = {};
     }
+
     let currentPriorityGroup: number | undefined = undefined;
     let promises: Promise<Response | void>[] = [];
-  
+
+    // handles only the promises in the current priority group & resets promises after processsing each group.
     const awaitResponses = async () => {
         await Promise.all(promises);
         promises = [];
     };
-  
+
     for (const preprocessor of preprocessors) {
+        // check if priority group changes - if so, wait for the current promises to finish
         if (preprocessor[2] !== currentPriorityGroup) {
             if (promises.length > 0) {
-            await awaitResponses();
+                await awaitResponses();
             }
             currentPriorityGroup = Number(preprocessor[2]);
-            console.debug(`Now on priority group ${currentPriorityGroup}`);
+            console.log("Now on priority group " + currentPriorityGroup);
         }
-  
-        // add the preprocessor lifecycle as a promise
-        promises.push(executePreprocessor(preprocessor, data));
+
+        // profile the request -- each preprocessor's entire lifecycle (fetch + response processing) is wrapped in measureExecutionTime
+        const promise = new Promise<void>((resolve) => {
+            // measure the execution time 
+            measureExecutionTime(`Preprocessor "${preprocessor[0]}"`, async () => {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => {
+                    controller.abort();
+                }, PREPROCESSOR_TIME_MS);
+
+                try {
+                    // get value from cache for each preprocessor if it exists
+                    const cacheTimeOut = preprocessor[3] as number;
+                    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
+                    const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
+
+                    const cacheValue = await serverCache.getResponseFromCache(hashedKey);
+
+                    if (cacheTimeOut > 0 && cacheValue && preprocessorName) {
+                        // Return the value from cache if found
+                        console.debug(`Response for preprocessor ${preprocessorName} served from cache`);
+                        const cacheResponse = JSON.parse(cacheValue) as Response;
+                        (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = cacheResponse;
+                        return; // Skip fetch if cache is valid
+                    }
+                    // Call the preprocessor endpoint to get response
+                    console.debug(`Sending to preprocessor "${preprocessor[0]}"`);
+                    const resp = await fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify(data),
+                        signal: controller.signal
+                    });
+
+                    clearTimeout(timeout);
+
+                    // Process the response
+                    if (resp.status === 200) {
+                        const json = await resp.json();
+                        if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", json)) {
+                            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP  
+                            (data["preprocessors"] as Record<string, unknown>)[json["name"]] = json["data"];
+                            SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = json["name"];
+                            // store data in cache
+                            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
+                            if (cacheTimeOut > 0) {
+                                console.debug(`Saving Response for ${json["name"]} in cache with key ${hashedKey}`);
+                                await serverCache.setResponseInCache(hashedKey, JSON.stringify(json["data"]), cacheTimeOut);
+                            }
+                        } else {
+                            console.error("Preprocessor response failed validation!");
+                            console.error(JSON.stringify(ajv.errors));
+                        }
+                    } else if (resp.status === 204) {
+                        // preprocessor not applicable
+                        return;
+                    } else {
+                        console.error(`Preprocessor "${preprocessor[0]}" responded with status ${resp.status}`);
+                    }
+                } catch (err) {
+                    console.error(`Error occurred fetching from ${preprocessor[0]}`);
+                    console.error(err);
+                }
+            }).finally(() => resolve()); // resolve the promise regardless of success or failure
+        }); // end of measureExecutionTime
+
+        promises.push(promise);
     }
-  
+
+    //wait for any remaining promises to resolve
     if (promises.length > 0) {
         await awaitResponses();
     }
-  
+
     return data;
-  }
-  
+}
 
 async function runPreprocessors(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -109,10 +109,10 @@ async function executePreprocessor(preprocessor: (string | number)[],data: Recor
   
         // fetch from the preprocessor
         const response = await fetch(`http://${preprocessor[0]}:${preprocessor[1]}/preprocessor`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(data),
-          signal: controller.signal,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+            signal: controller.signal,
         });
   
         clearTimeout(timeout);
@@ -155,25 +155,25 @@ async function executePreprocessor(preprocessor: (string | number)[],data: Recor
     let promises: Promise<Response | void>[] = [];
   
     const awaitResponses = async () => {
-      await Promise.all(promises);
-      promises = [];
+        await Promise.all(promises);
+        promises = [];
     };
   
     for (const preprocessor of preprocessors) {
-      if (preprocessor[2] !== currentPriorityGroup) {
-        if (promises.length > 0) {
-          await awaitResponses();
+        if (preprocessor[2] !== currentPriorityGroup) {
+            if (promises.length > 0) {
+            await awaitResponses();
+            }
+            currentPriorityGroup = Number(preprocessor[2]);
+            console.debug(`Now on priority group ${currentPriorityGroup}`);
         }
-        currentPriorityGroup = Number(preprocessor[2]);
-        console.debug(`Now on priority group ${currentPriorityGroup}`);
-      }
   
-      // add the preprocessor lifecycle as a promise
-      promises.push(executePreprocessor(preprocessor, data));
+        // add the preprocessor lifecycle as a promise
+        promises.push(executePreprocessor(preprocessor, data));
     }
   
     if (promises.length > 0) {
-      await awaitResponses();
+        await awaitResponses();
     }
   
     return data;


### PR DESCRIPTION
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

1. runPreprocessorsParallel, instead of hosting all the logic in an anonymous function, now solely manages execution by priority and calls executePreprocessor for each preprocessor.
2. executePreprocessor:
    * Checks the cache via checkCache. If a cache hit is found, the cached data is added to data["preprocessors"], and no further processing is needed.
    * If no cache hit is found, it proceeds to call fetchPreprocessorResponse.
    * Processes the response using processResponse, and it handles other response statuses.
3. All actions are wrapped in measureExecutionTime to log performance metrics.
4. runPreprocessorsParallel ensures all preprocessors are executed and returns the aggregated results.

Overall, the logic is preserved but there now exists an isolation of distinct responsibilities into separate functions. This also addresses the initial problem where the logging was not accurate due to the lack of modularity.
---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [X] I described the changes made and how these address the issue.
- [X] I described how I tested these changes.

## Coding/Commit Requirements

* [X] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [X] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [X] I have not added a new component in this PR.
