### PR TITLE
Deploy tactile authoring tool as service on IMAGE-server

### DIFF
--- a/.github/workflows/tat-service.yml
+++ b/.github/workflows/tat-service.yml
@@ -1,0 +1,78 @@
+name: Tactile Authoring Tool Service
+on:
+  push:
+    branches: [ main ]
+    tags: [ "service-tat-[0-9]+.[0-9]+.[0-9]+" ]
+    paths: [ "services/tat/**" ]
+  pull_request:
+    branches: [ main ]
+    paths: [ "services/tat/**" ]
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: shared-reality-lab/image-service-tat
+jobs:
+  lint:
+    name: PEP 8 style check.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install flake8
+        run: pip install flake8
+      - name: Check with flake8
+        run: python -m flake8 ./services/tat --show-source
+  build-and-push-image:
+    name: Build and Push to Registry
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Log into GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Correct Tags
+        run: |
+          if [[ ${{ github.ref }} =~ ^refs/tags/service-tat-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "TAGGED=true" >> $GITHUB_ENV
+          else
+            echo "TAGGED=false" >> $GITHUB_ENV
+          fi
+      - name: Get timestamp
+        run: echo "timestamp=$(date -u +'%Y-%m-%dT%H.%M')" >> $GITHUB_ENV
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ env.TAGGED }}
+          tags: |
+            type=match,enable=${{ env.TAGGED }},priority=300,pattern=service-tat-(\d+.\d+.\d+),group=1
+            type=raw,priority=200,value=unstable
+            type=raw,priority=100,value=${{ env.timestamp }}
+          labels: |
+            org.opencontainers.image.title=IMAGE Service Monarch Link App
+            org.opencontainers.image.description=Service to link Monarch client with tactile authoring tool.
+            org.opencontainers.image.authors=IMAGE Project <image@cim.mcgill.ca>
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+            maintainer=IMAGE Project <image@cim.mcgill.ca>
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./services/tat/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/build.yml
+++ b/build.yml
@@ -26,6 +26,11 @@ services:
             context: .
             dockerfile: services/monarch-link-app/Dockerfile
         image: "monarch-link-app:latest"
+    tat-service:
+        build:
+            context: .
+            dockerfile: services/tat/Dockerfile
+        image: "tat:latest"
     line-charts-preprocessor:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,6 +409,13 @@ services:
     restart: unless-stopped
     networks:
       - traefik
+  
+  tat:
+    profiles: [test, default]
+    image: "ghcr.io/shared-reality-lab/image-service-tat:${REGISTRY_TAG}"
+    restart: unless-stopped
+    networks:
+      - traefik
 # end - unicorn exclusive services        
 volumes:
   sc-store:

--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -1,0 +1,46 @@
+# Stage 1: Build the application
+FROM node:20-alpine as build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the package.json and package-lock.json to install dependencies
+# COPY /services/tat/IMAGE-TactileAuthoring/package*.json ./
+
+# Copy complete application code
+COPY /services/tat/IMAGE-TactileAuthoring/ .
+
+# Install only production dependencies
+#ENV NODE_ENV=production
+#RUN npm install
+
+# Install dependencies
+RUN npm install
+
+
+# Build the application
+# RUN npm run build
+
+# Set npm to ignore scripts
+ENV npm_config_ignore_scripts=true
+
+# Run build manually ignoring scripts
+WORKDIR /app/packages/svgcanvas
+RUN npx rollup -c
+WORKDIR /app
+RUN npx rollup -c
+
+# Stage 2: Serve the application
+FROM nginx:alpine
+
+# Copy the build output from the previous stage to the Nginx HTML directory
+COPY --from=build /app/dist/editor/ /usr/share/nginx/html
+
+# Copy a custom Nginx configuration file, if needed (optional)
+# COPY nginx.conf /etc/nginx/nginx.conf
+
+# Expose the default Nginx port
+EXPOSE 80
+
+# Start the Nginx server
+CMD ["nginx", "-g", "daemon off;"]

--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -4,15 +4,10 @@ FROM node:20-alpine as build
 # Set the working directory inside the container
 WORKDIR /app
 
-# Copy the package.json and package-lock.json to install dependencies
-# COPY /services/tat/IMAGE-TactileAuthoring/package*.json ./
-
-# Copy complete application code
-COPY /services/tat/IMAGE-TactileAuthoring/ .
-
-# Install only production dependencies
-#ENV NODE_ENV=production
-#RUN npm install
+# Clone git repo into app dir
+RUN apk add git
+RUN git clone https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring.git \
+    --depth 1 --single-branch .
 
 # Install dependencies
 RUN npm install

--- a/services/tat/README.md
+++ b/services/tat/README.md
@@ -1,0 +1,12 @@
+# Tactile Authoring Tool (TAT)
+
+![license: AGPL](https://img.shields.io/badge/license-AGPL-success) [GitHub Container Registry Package](https://github.com/Shared-Reality-Lab/IMAGE-server/pkgs/container/image-service-tat)
+
+## Overview
+
+This is the containerized version of the web app [IMAGE-TactileAuthoring](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring) used to publish to [IMAGE-Monarch client](https://github.com/Shared-Reality-Lab/IMAGE-Monarch) via [monarch-link-app](https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/monarch-link-app).
+
+This container runs on port 80.
+
+## Endpoints
+- GET `https://tat.unicorn.cim.mcgill.ca/` opens the web application on a web browser. It has been tested for Chrome (but could also work for recent versions of Safari and Firefox as per [the application's parent repo](https://github.com/SVG-Edit/svgedit))

--- a/services/tat/README.md
+++ b/services/tat/README.md
@@ -6,6 +6,8 @@
 
 This is the containerized version of the web app [IMAGE-TactileAuthoring](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring) used to publish to [IMAGE-Monarch client](https://github.com/Shared-Reality-Lab/IMAGE-Monarch) via [monarch-link-app](https://github.com/Shared-Reality-Lab/IMAGE-server/tree/main/services/monarch-link-app).
 
+While this app is included in the same docker-compose as other components of the IMAGE architecture, it is not a "service" in the specific sense the term is used within the IMAGE architecture. This web app is not used by any handlers/preprocessors within IMAGE. Instead, it is a standalone application related to IMAGE and is included in the docker-compose solely for convenience and ease of deployment.
+
 This container runs on port 80.
 
 ## Endpoints

--- a/test-docker-compose.yml
+++ b/test-docker-compose.yml
@@ -113,6 +113,15 @@ services:
     environment:
       - SERVER_NAME=unicorn.cim.mcgill.ca
 
+  tat:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tat.rule=Host(`tat.unicorn.cim.mcgill.ca`)"
+      - "traefik.http.routers.tat.tls.certresolver=myresolver"
+      - traefik.docker.network=traefik
+    environment:
+      - SERVER_NAME=unicorn.cim.mcgill.ca
+
   object-grouping:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]


### PR DESCRIPTION
These changes incorporate the [tactile authoring tool (TAT)](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring) as a service on the IMAGE-server. An additional Dockerfile and entries to docker-compose.yml and build.yml have been incorporated for this.

The Dockerfile clones the [IMAGE-TactileAuthoring repo](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring) and builds it. The application can be accessed on 'https://tat.unicorn.cim.mcgill.ca/'

TESTING: 
Tested that the application is deployed and can be accessed on https://tat.unicorn.cim.mcgill.ca/. It is also able to publish graphics to the monarch-link-app. (Please advise on any further testing!) 

This covers item **1.** Shared-Reality-Lab/IMAGE-browser#391

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [x] I added an entry to `docker-compose.yml` and `build.yml`.
* [x] I created A CI workflow under `.github/workflows`.
* [x] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
