### PR TITLE
remove logging.debug output that may contain PII for production push

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -131,7 +131,8 @@ def categorise():
         finally:
             if ollama_error_msg is not None:
                 logging.error(ollama_error_msg)
-                logging.debug(f"raw response (pii) [{graphic_category_json}]")
+                # TODO: add back next line once IMAGE-server #912 is complete
+                # logging.debug(f"response (pii) [{graphic_category_json}]")
                 return jsonify("Invalid LLM results"), 204
 
         # is the found category  one of the ones we require?

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -125,7 +125,8 @@ def categorise():
         validator.validate(graphic_caption_json)
     except jsonschema.exceptions.ValidationError as e:
         logging.error(f"JSON schema validation fail: {e.validator} {e.schema}")
-        logging.debug(e)  # print full error only in debug, due to PII
+        # TODO: add back next line once IMAGE-server #941 is complete
+        # logging.debug(e)  # print full error only in debug, due to PII
         return jsonify("Invalid Preprocessor JSON format"), 500
 
     # create full response & check meets overall preprocessor response schema
@@ -140,7 +141,8 @@ def categorise():
         validator.validate(response)
     except jsonschema.exceptions.ValidationError as e:
         logging.error(f"JSON schema validation fail: {e.validator} {e.schema}")
-        logging.debug(e)  # print full error only in debug, due to PII
+        # TODO: add back next line once IMAGE-server #912 is complete
+        # logging.debug(e)  # print full error only in debug, due to PII
         return jsonify("Invalid Preprocessor JSON format"), 500
 
     # all done; return to orchestrator


### PR DESCRIPTION
Until #912 is fixed, we do not want to risk PII going into logs. This removes several logging.debug lines from `content-categoriser` and `graphic-caption` preprocessors, to be reinstated once #912 is completed.

Tested on several photos to make sure nothing else appears to be leaking, and that commenting out these lines didn't introduce any issues.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [X] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
