### PR TITLE
Initial commit using captioner

### DIFF
--- a/handlers/photo-audio-handler/src/utils.ts
+++ b/handlers/photo-audio-handler/src/utils.ts
@@ -247,6 +247,17 @@ export function generateObjDet(objDet: ObjDet, objGroup: ObjGroup, actionRec: Ac
     return objects;
 }
 
+export function generateCaption(capObj: {caption: string}): TTSSegment[] {
+    return [{
+        "type": "text",
+        "value": "has the following description:"
+    }, {
+        "type": "text",
+        "value": capObj["caption"],
+        "label": "Generated caption"
+    }];
+}
+
 /**
  * Get translation from multilang-support service
  * @param inputSegment array of text to be translated


### PR DESCRIPTION
This resolves #933 by checking for preprocessor data under the `graphic-caption` object. If a caption is present, it is inserted at the start of the description, before semantic segmentation or object detection. Changes are made so that if only the caption information is available, the handler will still run.

There is likely to be considerable redundancy between these three sources of data.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
