### PR TITLE
Fix path to text-followup-handler in workflow

### DIFF
--- a/.github/workflows/text-followup-handler.yml
+++ b/.github/workflows/text-followup-handler.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: [ main ]
     tags: [ "handler-text-followup-[0-9]+.[0-9]+.[0-9]+" ]
-    paths: [ "handlers/text-followup/**" ]
+    paths: [ "handlers/text-followup-handler/**" ]
   pull_request:
     branches: [ main ]
-    paths: [ "handlers/text-followup/**" ]
+    paths: [ "handlers/text-followup-handler/**" ]
   workflow_run:
     workflows: [ "Schemas (Trigger)" ]
     types:
@@ -27,7 +27,7 @@ jobs:
       - name: Install flake8
         run: pip install flake8
       - name: Check with flake8
-        run: python -m flake8 ./handlers/text-followup --show-source
+        run: python -m flake8 ./handlers/text-followup-handler --show-source
   build-and-push-image:
     name: Build and Push to Registry
     needs: lint
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./handlers/text-followup/Dockerfile
+          file: ./handlers/text-followup-handler/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION

Fixed the path of text-followup-handler in workflow. 
This handler was merged in #948 but I hadn't noticed that the workflow had not run owing to incorrect file path. This is fixed with this PR. 

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
