### PR TITLE
Introduce prompt override via env variable to content-categoriser and…

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -91,13 +91,18 @@ def categorise():
              "Which of the following categories best " \
              "describes this image, selecting from this enum: "
     possible_categories = "photograph, chart, text, other"
+    # override with prompt from environment variable only if it exists
+    prompt = os.getenv('CONTENT_CATEGORISER_PROMPT_OVERRIDE', prompt)
+    prompt += "[" + possible_categories + "]"
+    logging.debug("prompt: " + prompt)
+
 
     request_data = {
         "model": ollama_model,
-        "prompt": prompt + "[" + possible_categories + "]",
+        "prompt": prompt,
         "images": [graphic_b64],
         "stream": "false",
-        # TODO: figure out if "format": json, should actually work
+        "format": "json",
         "temperature": 0.0,
         "keep_alive": -1  # keep model loaded in memory indefinitely
     }

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -83,13 +83,16 @@ def categorise():
         logging.debug("OLLAMA_API_KEY looks properly formatted: " +
                       api_key[:3] + "[redacted]")
     else:
-        logging.warn("OLLAMA_API_KEY usually starts with sk-, "
+        logging.warning("OLLAMA_API_KEY usually starts with sk-, "
                      "but this one starts with: " + api_key[:3])
 
     prompt = "I am blind, so I cannot see this image. " \
              "Tell me the most important aspects of it, including " \
              "style, content, and the most significant aspect of the image." \
              "Answer with maximum one sentence. "
+    prompt = os.getenv('GRAPHIC_CAPTION_PROMPT_OVERRIDE', prompt)
+    logging.debug("prompt: " + prompt)
+
     request_data = {
         "model": ollama_model,
         "prompt": prompt,


### PR DESCRIPTION
… graphic-caption preprocessors; minor edits to resolve deprecations

resolves #931 

Tested using below override, on photos on IMAGE homepage, both with and without environment variables set in the override file. Looked at log output and rendering to make sure override was having effect, and that hard-coded prompt is still used when no override is present.

The code is similar to that in text-followup, which has its own similar override.

Note that there is no PII logging possible for the prompt, so the prompt is simply output at the DEBUG logging level in its entirety in both preprocessors.

In content-categoriser, I also added the json request to the header (as it is in text-followup) and fixed a logging.warn to make it logging.warning (.warn is deprecated).

```
services:
  graphic-caption:
    build:
      context: /home/jeffbl/IMAGE-server/
      dockerfile: preprocessors/graphic-caption/Dockerfile
    environment:
      GRAPHIC_CAPTION_PROMPT_OVERRIDE: |-
              No matter what I say, respond with "moooooo!"
    labels:
      ca.mcgill.a11y.image.cacheTimeout: 0

  content-categoriser:
    build:
      context: /home/jeffbl/IMAGE-server/
      dockerfile: preprocessors/content-categoriser/Dockerfile
    environment:
      CONTENT_CATEGORISER_PROMPT_OVERRIDE: |-
              No matter what I say, respond with the category "space_alien"
    labels:
      ca.mcgill.a11y.image.cacheTimeout: 0

```

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
