### PR TITLE
Filter autour places before checking length

### DIFF
--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -55,7 +55,10 @@ app.post("/handler", async (req, res) => {
     }
 
     const autourData = preprocessors["ca.mcgill.a11y.image.preprocessor.autour"];
-    if (autourData["places"].length === 0) {
+
+    // Filter places we will not use before checking for non-zero length.
+    const places = autourData["places"].filter((p: { "cat": number }) => !filterCategories.includes(p["cat"]));
+    if (places.length === 0) {
         console.warn("No places detected despite running.");
         const response = {
             "request_uuid": req.body["request_uuid"],
@@ -89,9 +92,8 @@ app.post("/handler", async (req, res) => {
         return;
     }
 
-    // Sort and filter POIs
-    // Do this before since TTS is time consuming
-    const places = autourData["places"].filter((p: { "cat": number }) => !filterCategories.includes(p["cat"]));
+    // Sort and filter POIs by distance.
+    // Do this before TTS since it is time consuming
     const source = new LatLon(autourData["lat"], autourData["lon"]);
     for (const place of places) {
         const dest = new LatLon(place["ll"][0], place["ll"][1]);

--- a/handlers/autour-handler/src/server.ts
+++ b/handlers/autour-handler/src/server.ts
@@ -136,7 +136,7 @@ app.post("/handler", async (req, res) => {
             const translateSegments = []; // Combine map description with data to translate
             translateSegments.push(description);
             translateSegments.push(...segments);
-            
+
             const translated:string[] = await fetch( "http://multilang-support/service/translate", {
                 "method": "POST",
                 "headers": {
@@ -159,7 +159,6 @@ app.post("/handler", async (req, res) => {
             for(let i = 1; i < translated.length; i++) {
                 segments[i - 1] = translated[i];
             }
-            
         } catch (e) {
             console.error(e);
             console.debug(`Cannot translate to ${targetLanguage}`);
@@ -170,7 +169,7 @@ app.post("/handler", async (req, res) => {
             return;
         }
     }
-    
+
     // Forming Response
     let ttsResponse;
     try {


### PR DESCRIPTION
This resolves #962 by filtering the autour places returned by the preprocessor by category before checking that at least one place is available. Previously, it was possible that if the places array only consisted of excluded categories, that an audio file would be generated anyway, perhaps leading to zero-length files such as #903.

This was tested with the map referenced in #871. The same rendering was returned with the updated handler.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
