### PR TITLE
Cache item size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
     profiles: [production, test, default]
     image: 'memcached:1.6'
     restart: unless-stopped
-    # cache memory size - 4GB
-    command: -m 4096
+    # cache memory size - 4GB, maximum item size - 5MB
+    command: -m 4096 -I 5m
 
   espnet-tts:
     profiles: [production, test, default]

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -85,7 +85,7 @@ This docker group ID changes from system to system and needs to be checked manua
 
 IMAGE uses Memcached as in-memory data store. Cache is implemented using [MemJS](https://www.npmjs.com/package/memjs). Following is the confugration to enable Cache for preprocessors:
 
-- Cache size is configured in the docker-compose in the commad attribute under memcached service `command: -m 4096` implies cache size of 4GB.
+- Cache size and max item size is configured in the docker-compose in the command attribute under memcached service `command: -m 4096 -I 5m` implies cache size of 4GB and maximum item size of 5MB.
 
 - Cache timeout is configured at the preprocessor level, with the label `ca.mcgill.a11y.image.cacheTimeout` . Label value is the timeout value in seconds. Timeout value of 0 indicates that Cache is disabled for a preprocessor. Missing `ca.mcgill.a11y.image.cacheTimeout` label on the preprocessor will default to timeout value of 0.
 


### PR DESCRIPTION
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.

This PR provides fix for https://github.com/Shared-Reality-Lab/IMAGE-server/issues/832 . The fix is to override the default item size (1MB) and increase it to 5 MB. There were certain cases like #832 where the semantic segmentation output was too large and memache was giving error while setting the value 

Fix has been validated on Unicorn, the response for the bookshelf image is now correctly served from cache.

Before Fix:
![image](https://github.com/user-attachments/assets/3a871b99-577d-49d9-a199-0f4693928c4a)

After Fix: 
Response Stored in Cache: 
![image](https://github.com/user-attachments/assets/a97613ca-11d7-4693-aa7a-d3786a4ce6ac)

Response Served from Cache:
![image](https://github.com/user-attachments/assets/cd1b9735-ac8f-446e-9ca2-af451fab91d4)


Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
