### PR TITLE
Add chat history preservation, deleteion, and cleanup

### DIFF
--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -26,6 +26,33 @@ from datetime import datetime
 app = Flask(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
+# ADDED: Dictionary to store conversation history by request_uuid
+# We'll use this to maintain conversation context between requests
+conversation_history = {}
+
+# ADDED: Configuration for history management
+MAX_HISTORY_LENGTH = int(os.getenv('MAX_HISTORY_LENGTH', '50'))  # Max messages to keep
+HISTORY_EXPIRY = int(os.getenv('HISTORY_EXPIRY', '30'))  # History expiry in seconds
+
+
+# ADDED: Function to clean up old conversation histories
+def cleanup_old_histories():
+    """
+    Remove conversation histories that are older than HISTORY_EXPIRY seconds
+    """
+    current_time = time.time()
+    uuids_to_remove = []
+    
+    for uuid, history in conversation_history.items():
+        if current_time - history.get('last_updated', 0) > HISTORY_EXPIRY:
+            uuids_to_remove.append(uuid)
+    
+    for uuid in uuids_to_remove:
+        del conversation_history[uuid]
+    
+    if uuids_to_remove:
+        logging.debug(f"Cleaned up {len(uuids_to_remove)} old conversation histories")
+
 
 @app.route("/preprocessor", methods=['POST', ])
 def followup():
@@ -66,6 +93,15 @@ def followup():
     request_uuid = content["request_uuid"]
     timestamp = time.time()
     name = "ca.mcgill.a11y.image.preprocessor.text-followup"
+
+    # ADDED: Clean up history based on defined expiry time
+    cleanup_old_histories()
+
+    # ADDED: History status log
+    logging.debug(f"Current history status: {len(conversation_history)} conversations stored")
+    logging.debug(f"Request UUID {request_uuid} exists in history: {request_uuid in conversation_history}")
+    if request_uuid in conversation_history:
+        logging.debug(f"Current history length for {request_uuid}: {len(conversation_history[request_uuid]['messages'])}")
 
     # debugging this preprocessor is really difficult without seeing what
     # ollama is returning, but this can contain PII. Until we have a safe
@@ -113,14 +149,15 @@ def followup():
     # override with prompt from environment variable only if it exists
     general_prompt = os.getenv('TEXT_FOLLOWUP_PROMPT_OVERRIDE', general_prompt)
     user_prompt = content["followup"]["query"]
-    prompt = general_prompt + ' ' + user_prompt
+    prompt = general_prompt + ' ' + user_prompt # not needed - delete if approved
     if log_pii:
         logging.debug("user followup prompt: " + prompt)
     else:
         logging.debug("user followup prompt: {general_prompt} [redacted]")
 
     # prepare ollama request
-    api_url = os.environ['OLLAMA_URL']
+    # api_url = os.environ['OLLAMA_URL']
+    api_url = "https://ollama.pegasus.cim.mcgill.ca/ollama/api/chat" # ATTENTION: Temp override
     api_key = os.environ['OLLAMA_API_KEY']
     ollama_model = os.environ['OLLAMA_MODEL']
 
@@ -130,16 +167,70 @@ def followup():
                       "sk-[redacted]")
     else:
         logging.warning("OLLAMA_API_KEY does not start with sk-")
+    
+    # MODIFIED: Create messages list for chat endpoint instead of single prompt
+    system_message = {
+        "role": "system",
+        "content": general_prompt
+    }
+    
+    # Discuss if we want to attach the image every time
+    user_message = {
+        "role": "user",
+        "content": user_prompt,
+        "images": [graphic_b64]
+    }
+    
+    # ADDED: Retrieve existing conversation history or create new one
+    if request_uuid in conversation_history:
+        # Add new user message
+        conversation_history[request_uuid]['messages'].append(user_message)
+        conversation_history[request_uuid]['last_updated'] = timestamp
+    else:
+        # Start a new conversation with system and user messages
+        conversation_history[request_uuid] = {
+            'messages': [system_message, user_message],
+            'last_updated': timestamp
+        }
 
+    # ADDED: use history for the request
+    messages = conversation_history[request_uuid]['messages'][-MAX_HISTORY_LENGTH:]
+
+    # ADDED: Create log-friendly version of messages without full base64 content
+    log_friendly_messages = []
+    for msg in messages:
+        log_msg = msg.copy()  # Create a copy to avoid modifying the original
+        if 'images' in log_msg:
+            # Replace image content with placeholder or truncate it
+            log_msg['images'] = [f"[BASE64_IMAGE:{len(img)} bytes]" for img in log_msg['images']]
+        log_friendly_messages.append(log_msg)
+
+    logging.debug(f"Message history: {log_friendly_messages}")
+
+    # MODIFIED: Create request data for chat endpoint
     request_data = {
         "model": ollama_model,
-        "prompt": prompt,
-        "images": [graphic_b64],
+        "messages": messages,
         "stream": False,
         "temperature": 0.0,
-        "format": "json",
+        "format": {
+            "type": "object",
+            "properties": {
+                "response_brief": {
+                    "type": "string"
+                },
+                "response_full": {
+                    "type": "string"
+                }
+                },
+                "required": [
+                    "age",
+                    "available"
+                    ]
+        },
         "keep_alive": -1  # keep model loaded in memory indefinitely
     }
+
     logging.debug("serializing json from request_data dictionary")
     request_data_json = json.dumps(request_data)
 
@@ -157,10 +248,25 @@ def followup():
         ollama_error_msg = None
         try:
             # strip() at end since llama often puts a newline before json
-            response_text = json.loads(response.text)['response'].strip()
+            response_text = json.loads(response.text)['message']['content'].strip() # MODIFIED: text is located in message.content in the /chat response
             if log_pii:
                 logging.debug("raw ollama response: " + response_text)
             followup_response_json = json.loads(response_text)
+            
+            # ADDED: Format assistant response for history
+            assistant_message = {
+                "role": "assistant",
+                "content": response_text
+            }
+
+            # ADDED: Update conversation history
+            conversation_history[request_uuid]['messages'].append(assistant_message)
+            conversation_history[request_uuid]['last_updated'] = timestamp
+
+            # Add debug logging
+            logging.debug(f"Conversation history status: UUID {request_uuid} {'updated' if request_uuid in conversation_history else 'created'}")
+            logging.debug(f"History now contains {len(conversation_history)} conversation(s)")
+
         except json.JSONDecodeError:
             ollama_error_msg = "raw response does not look like json"
         except KeyError:
@@ -214,6 +320,44 @@ def followup():
     return response
 
 
+# ADDED: New endpoint to clear history for a specific request_uuid
+@app.route("/clear-history/<request_uuid>", methods=["GET"])
+def clear_history(request_uuid):
+    """
+    Clear conversation history for a specific request_uuid
+    """
+    logging.info(f"Request to clear history for {request_uuid}")
+    logging.info(f"Before clearing: {len(conversation_history)} conversations in memory")
+    logging.info(f"UUID exists in history: {request_uuid in conversation_history}")
+    
+    if request_uuid in conversation_history:
+        del conversation_history[request_uuid]
+        logging.info(f"After clearing: {len(conversation_history)} conversations in memory")
+        return jsonify({
+            "status": "success",
+            "message": f"History for {request_uuid} cleared"
+        }), 200
+    else:
+        logging.info("UUID not found in history")
+        return jsonify({
+            "status": "not_found",
+            "message": f"No history found for {request_uuid}"
+        }), 404
+
+
+# ADDED: New endpoint to get conversation statistics
+@app.route("/history-stats", methods=["GET"])
+def history_stats():
+    """
+    Get statistics about stored conversation histories
+    """
+    return jsonify({
+        "active_conversations": len(conversation_history),
+        "oldest_conversation": min([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None,
+        "newest_conversation": max([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None
+    }), 200
+
+
 @app.route("/health", methods=["GET"])
 def health():
     """
@@ -227,4 +371,4 @@ def health():
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)
-    followup()
+    # followup() - not needed


### PR DESCRIPTION
Resolve #970 

Summary of changes:
* Set up in-memory storage for chat history
* Chats are stored based on the request_uuid
* Added chat history length and history expiry. TO DO: discuss these figures and add them to .env
* Changed API endpoint from `generate` to `chat` to be able to pass chat history. TO DO: change it in the .env file
* Modified ollama request structure to include chat history
* Modified ollama request structure to include JSON schema
* Added chat history logging. TO DO: move it under the `log_pii` condition
* Added chat history cleanup after set time
* Added an endpoint to delete chat history for a specific uuid. TO DO: discuss if it's needed
* Added an endpoint to get conversation statistics. TO DO: discuss if it's needed

Testing:
* Tested using jQuery requests and asking follow-up questions on the same picture
* Logging shows that the chat history is passed along with each new request from the same uuid
* Model answers are cohesive; the model is able to reference its previous responses
* Chat history cleanup works as intended: after the set time, the conversations are deleted, and new dialogues start from scratch - checked via logs.

To do:
* Items described in the summary
* Testing of `/clear-history` and `history-stats` endpoints

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
