### PR TITLE
Specify ollama API endpoints for each preprocessor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,9 @@ services:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-text-followup:${REGISTRY_TAG}
     restart: unless-stopped
+    environment:
+      - MAX_HISTORY_LENGTH=100
+      - HISTORY_EXPIRY=3600
     labels:
       ca.mcgill.a11y.image.preprocessor: 1
       ca.mcgill.a11y.image.port: 5000

--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -74,7 +74,7 @@ def categorise():
     graphic_b64 = source.split(",")[1]
 
     # prepare ollama request
-    api_url = os.environ['OLLAMA_URL']
+    api_url = f"{os.environ['OLLAMA_URL']}/generate"
     api_key = os.environ['OLLAMA_API_KEY']
     ollama_model = os.environ['OLLAMA_MODEL']
 

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -74,7 +74,7 @@ def categorise():
     graphic_b64 = source.split(",")[1]
 
     # prepare ollama request
-    api_url = os.environ['OLLAMA_URL']
+    api_url = f"{os.environ['OLLAMA_URL']}/generate"
     api_key = os.environ['OLLAMA_API_KEY']
     ollama_model = os.environ['OLLAMA_MODEL']
 

--- a/preprocessors/text-followup/README.md
+++ b/preprocessors/text-followup/README.md
@@ -6,14 +6,19 @@ and a question posed by the user.
 A brief and a full response are included, and together
 form the full response.
 
+The preprocessor keeps the memory of the conversation
+allowing users to ask follow-up questions about the original graphic.
+The period of history storage is defined by
+the `HISTORY_EXPIRY` environment variable (default is 1 hour).
+
 It uses an LLM model running via ollama fronted by open-webui.
 There are several mandatory environment variables you must set.
 Example ollama.env file:
 
 ```
-OLLAMA_URL=https://ollama.myserver.com/ollama/api/generate
+OLLAMA_URL=https://ollama.myserver.com/ollama/api
 OLLAMA_API_KEY=sk-[YOUR_OLLAMA_SECRET KEY]
-OLLAMA_MODEL=llava:latest
+OLLAMA_MODEL=llama3.2-vision:latest
 ```
 Note these are not unique to this preprocessor. Due to
 GPU memory limitations, we assume that all preprocessors

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -26,35 +26,42 @@ from datetime import datetime
 app = Flask(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
-# ADDED: Dictionary to store conversation history by request_uuid
-# We'll use this to maintain conversation context between requests
+# Dictionary to store conversation history by request_uuid
+# Maintains conversation context between requests
 conversation_history = {}
 
-# ADDED: Configuration for history management
-MAX_HISTORY_LENGTH = int(os.getenv('MAX_HISTORY_LENGTH', '50'))  # Max messages to keep
-HISTORY_EXPIRY = int(os.getenv('HISTORY_EXPIRY', '30'))  # History expiry in seconds
+# Configuration for history management
+# Max messages to keep (including user and model messages)
+MAX_HISTORY_LENGTH = int(os.getenv('MAX_HISTORY_LENGTH', '100'))
+# History expiry in seconds after the last message
+HISTORY_EXPIRY = int(os.getenv('HISTORY_EXPIRY', '3600'))
 
 
-# ADDED: Function to clean up old conversation histories
+# Function to clean up old conversation histories
+@app.route("/cleanup", methods=["GET"])
 def cleanup_old_histories():
     """
     Remove conversation histories that are older than HISTORY_EXPIRY seconds
     """
     current_time = time.time()
     uuids_to_remove = []
-    
+
     for uuid, history in conversation_history.items():
         if current_time - history.get('last_updated', 0) > HISTORY_EXPIRY:
             uuids_to_remove.append(uuid)
-    
+
     for uuid in uuids_to_remove:
         del conversation_history[uuid]
-    
+
     if uuids_to_remove:
-        logging.debug(f"Cleaned up {len(uuids_to_remove)} old conversation histories")
+        logging.debug(
+            f"Cleaned up {len(uuids_to_remove)} old conversation histories"
+        )
+
+    return {"status": "success", "removed": len(uuids_to_remove)}, 200
 
 
-@app.route("/preprocessor", methods=['POST', ])
+@app.route("/preprocessor", methods=['POST'])
 def followup():
     logging.debug("Received request")
 
@@ -94,14 +101,25 @@ def followup():
     timestamp = time.time()
     name = "ca.mcgill.a11y.image.preprocessor.text-followup"
 
-    # ADDED: Clean up history based on defined expiry time
+    # Clean up history based on defined expiry time
     cleanup_old_histories()
 
-    # ADDED: History status log
-    logging.debug(f"Current history status: {len(conversation_history)} conversations stored")
-    logging.debug(f"Request UUID {request_uuid} exists in history: {request_uuid in conversation_history}")
-    if request_uuid in conversation_history:
-        logging.debug(f"Current history length for {request_uuid}: {len(conversation_history[request_uuid]['messages'])}")
+    # History status log
+    conversation_count = len(conversation_history)
+    logging.debug(
+        f"Current history status: {conversation_count} conversations stored"
+    )
+
+    # Check if this uuid exists in history
+    uuid_exists = request_uuid in conversation_history
+    logging.debug(
+        f"Request UUID {request_uuid} exists in history: {uuid_exists}"
+    )
+    if uuid_exists:
+        msg_count = len(conversation_history[request_uuid]["messages"])
+        logging.debug(
+            f"Current history length for {request_uuid}: {msg_count}"
+            )
 
     # debugging this preprocessor is really difficult without seeing what
     # ollama is returning, but this can contain PII. Until we have a safe
@@ -149,15 +167,13 @@ def followup():
     # override with prompt from environment variable only if it exists
     general_prompt = os.getenv('TEXT_FOLLOWUP_PROMPT_OVERRIDE', general_prompt)
     user_prompt = content["followup"]["query"]
-    prompt = general_prompt + ' ' + user_prompt # not needed - delete if approved
     if log_pii:
-        logging.debug("user followup prompt: " + prompt)
+        logging.debug(f"user followup prompt: {general_prompt} {user_prompt}")
     else:
-        logging.debug("user followup prompt: {general_prompt} [redacted]")
+        logging.debug(f"user followup prompt: {general_prompt} [redacted]")
 
     # prepare ollama request
-    # api_url = os.environ['OLLAMA_URL']
-    api_url = "https://ollama.pegasus.cim.mcgill.ca/ollama/api/chat" # ATTENTION: Temp override
+    api_url = f"{os.environ['OLLAMA_URL']}/chat"
     api_key = os.environ['OLLAMA_API_KEY']
     ollama_model = os.environ['OLLAMA_MODEL']
 
@@ -167,47 +183,52 @@ def followup():
                       "sk-[redacted]")
     else:
         logging.warning("OLLAMA_API_KEY does not start with sk-")
-    
-    # MODIFIED: Create messages list for chat endpoint instead of single prompt
+
+    # Create messages list for chat endpoint instead of single prompt
     system_message = {
         "role": "system",
         "content": general_prompt
     }
-    
-    # Discuss if we want to attach the image every time
+
     user_message = {
         "role": "user",
         "content": user_prompt,
-        "images": [graphic_b64]
     }
-    
-    # ADDED: Retrieve existing conversation history or create new one
-    if request_uuid in conversation_history:
+
+    # Retrieve existing conversation history or create new one
+    if uuid_exists:
         # Add new user message
         conversation_history[request_uuid]['messages'].append(user_message)
         conversation_history[request_uuid]['last_updated'] = timestamp
     else:
+        # Attach the image to the first request
+        user_message["images"] = [graphic_b64]
         # Start a new conversation with system and user messages
         conversation_history[request_uuid] = {
             'messages': [system_message, user_message],
             'last_updated': timestamp
         }
 
-    # ADDED: use history for the request
-    messages = conversation_history[request_uuid]['messages'][-MAX_HISTORY_LENGTH:]
+    # Use history for the request
+    uuid_messages = conversation_history[request_uuid]["messages"]
+    messages = uuid_messages[-MAX_HISTORY_LENGTH:]
 
-    # ADDED: Create log-friendly version of messages without full base64 content
-    log_friendly_messages = []
-    for msg in messages:
-        log_msg = msg.copy()  # Create a copy to avoid modifying the original
-        if 'images' in log_msg:
-            # Replace image content with placeholder or truncate it
-            log_msg['images'] = [f"[BASE64_IMAGE:{len(img)} bytes]" for img in log_msg['images']]
-        log_friendly_messages.append(log_msg)
+    # Create log-friendly version without full base64 content
+    if log_pii:
+        log_friendly_messages = []
+        for msg in messages:
+            # Create a copy to avoid modifying the original
+            log_msg = msg.copy()
+            if 'images' in log_msg:
+                # Replace image content with placeholder or truncate it
+                log_msg['images'] = [
+                    f"[BASE64_IMAGE:{len(img)} bytes]"
+                    for img in log_msg['images']
+                ]
+            log_friendly_messages.append(log_msg)
+            logging.debug(f"Message history: {log_friendly_messages}")
 
-    logging.debug(f"Message history: {log_friendly_messages}")
-
-    # MODIFIED: Create request data for chat endpoint
+    # Create request data for chat endpoint
     request_data = {
         "model": ollama_model,
         "messages": messages,
@@ -216,19 +237,12 @@ def followup():
         "format": {
             "type": "object",
             "properties": {
-                "response_brief": {
-                    "type": "string"
-                },
-                "response_full": {
-                    "type": "string"
-                }
-                },
-                "required": [
-                    "age",
-                    "available"
-                    ]
+                "response_brief": {"type": "string"},
+                "response_full": {"type": "string"},
+            },
+            "required": ["response_brief", "response_full"],
         },
-        "keep_alive": -1  # keep model loaded in memory indefinitely
+        "keep_alive": -1,  # keep model loaded in memory indefinitely
     }
 
     logging.debug("serializing json from request_data dictionary")
@@ -247,25 +261,31 @@ def followup():
     if response.status_code == 200:
         ollama_error_msg = None
         try:
+            response_json = json.loads(response.text)
             # strip() at end since llama often puts a newline before json
-            response_text = json.loads(response.text)['message']['content'].strip() # MODIFIED: text is located in message.content in the /chat response
+            response_text = response_json['message']['content'].strip()
             if log_pii:
                 logging.debug("raw ollama response: " + response_text)
             followup_response_json = json.loads(response_text)
-            
-            # ADDED: Format assistant response for history
-            assistant_message = {
+
+            # Format assistant response for history
+            model_resp = {
                 "role": "assistant",
                 "content": response_text
             }
 
-            # ADDED: Update conversation history
-            conversation_history[request_uuid]['messages'].append(assistant_message)
-            conversation_history[request_uuid]['last_updated'] = timestamp
+            # Update conversation history
+            conversation_history[request_uuid]["messages"].append(model_resp)
+            conversation_history[request_uuid]["last_updated"] = timestamp
 
             # Add debug logging
-            logging.debug(f"Conversation history status: UUID {request_uuid} {'updated' if request_uuid in conversation_history else 'created'}")
-            logging.debug(f"History now contains {len(conversation_history)} conversation(s)")
+            status = 'updated' if uuid_exists else 'created'
+            logging.debug(
+                f"Conversation history status: UUID {request_uuid} {status}"
+            )
+            logging.debug(
+                f"History contains {len(conversation_history)} conversations"
+                )
 
         except json.JSONDecodeError:
             ollama_error_msg = "raw response does not look like json"
@@ -320,19 +340,27 @@ def followup():
     return response
 
 
-# ADDED: New endpoint to clear history for a specific request_uuid
+# Two following endpoints don't have immediate use
+# They are implemented in case we need to extend functionality later
+# They are tested and fully functional
+# New endpoint to clear history for a specific request_uuid
 @app.route("/clear-history/<request_uuid>", methods=["GET"])
 def clear_history(request_uuid):
     """
     Clear conversation history for a specific request_uuid
     """
+    uuid_exists = request_uuid in conversation_history
     logging.info(f"Request to clear history for {request_uuid}")
-    logging.info(f"Before clearing: {len(conversation_history)} conversations in memory")
-    logging.info(f"UUID exists in history: {request_uuid in conversation_history}")
-    
-    if request_uuid in conversation_history:
+    logging.info(
+        f"Before clearing: {len(conversation_history)} conversations in memory"
+    )
+    logging.info(f"UUID exists in history: {uuid_exists}")
+
+    if uuid_exists:
         del conversation_history[request_uuid]
-        logging.info(f"After clearing: {len(conversation_history)} conversations in memory")
+        logging.info(
+            f"After clearing: {len(conversation_history)} conversations"
+            )
         return jsonify({
             "status": "success",
             "message": f"History for {request_uuid} cleared"
@@ -345,17 +373,31 @@ def clear_history(request_uuid):
         }), 404
 
 
-# ADDED: New endpoint to get conversation statistics
+# New endpoint to get conversation statistics
 @app.route("/history-stats", methods=["GET"])
 def history_stats():
     """
     Get statistics about stored conversation histories
     """
-    return jsonify({
-        "active_conversations": len(conversation_history),
-        "oldest_conversation": min([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None,
-        "newest_conversation": max([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None
-    }), 200
+    history_data = conversation_history.values()
+    return (
+        jsonify(
+            {
+                "active_conversations": len(conversation_history),
+                "oldest_conversation": (
+                    min([h["last_updated"] for h in history_data])
+                    if conversation_history
+                    else None
+                ),
+                "newest_conversation": (
+                    max([h["last_updated"] for h in history_data])
+                    if conversation_history
+                    else None
+                ),
+            }
+        ),
+        200,
+    )
 
 
 @app.route("/health", methods=["GET"])
@@ -371,4 +413,3 @@ def health():
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)
-    # followup() - not needed

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -26,6 +26,33 @@ from datetime import datetime
 app = Flask(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
+# ADDED: Dictionary to store conversation history by request_uuid
+# We'll use this to maintain conversation context between requests
+conversation_history = {}
+
+# ADDED: Configuration for history management
+MAX_HISTORY_LENGTH = int(os.getenv('MAX_HISTORY_LENGTH', '50'))  # Max messages to keep
+HISTORY_EXPIRY = int(os.getenv('HISTORY_EXPIRY', '30'))  # History expiry in seconds
+
+
+# ADDED: Function to clean up old conversation histories
+def cleanup_old_histories():
+    """
+    Remove conversation histories that are older than HISTORY_EXPIRY seconds
+    """
+    current_time = time.time()
+    uuids_to_remove = []
+    
+    for uuid, history in conversation_history.items():
+        if current_time - history.get('last_updated', 0) > HISTORY_EXPIRY:
+            uuids_to_remove.append(uuid)
+    
+    for uuid in uuids_to_remove:
+        del conversation_history[uuid]
+    
+    if uuids_to_remove:
+        logging.debug(f"Cleaned up {len(uuids_to_remove)} old conversation histories")
+
 
 @app.route("/preprocessor", methods=['POST', ])
 def followup():
@@ -66,6 +93,15 @@ def followup():
     request_uuid = content["request_uuid"]
     timestamp = time.time()
     name = "ca.mcgill.a11y.image.preprocessor.text-followup"
+
+    # ADDED: Clean up history based on defined expiry time
+    cleanup_old_histories()
+
+    # ADDED: History status log
+    logging.debug(f"Current history status: {len(conversation_history)} conversations stored")
+    logging.debug(f"Request UUID {request_uuid} exists in history: {request_uuid in conversation_history}")
+    if request_uuid in conversation_history:
+        logging.debug(f"Current history length for {request_uuid}: {len(conversation_history[request_uuid]['messages'])}")
 
     # debugging this preprocessor is really difficult without seeing what
     # ollama is returning, but this can contain PII. Until we have a safe
@@ -113,14 +149,15 @@ def followup():
     # override with prompt from environment variable only if it exists
     general_prompt = os.getenv('TEXT_FOLLOWUP_PROMPT_OVERRIDE', general_prompt)
     user_prompt = content["followup"]["query"]
-    prompt = general_prompt + ' ' + user_prompt
+    prompt = general_prompt + ' ' + user_prompt # not needed - delete if approved
     if log_pii:
         logging.debug("user followup prompt: " + prompt)
     else:
         logging.debug("user followup prompt: {general_prompt} [redacted]")
 
     # prepare ollama request
-    api_url = os.environ['OLLAMA_URL']
+    # api_url = os.environ['OLLAMA_URL']
+    api_url = "https://ollama.pegasus.cim.mcgill.ca/ollama/api/chat" # ATTENTION: Temp override
     api_key = os.environ['OLLAMA_API_KEY']
     ollama_model = os.environ['OLLAMA_MODEL']
 
@@ -130,16 +167,70 @@ def followup():
                       "sk-[redacted]")
     else:
         logging.warning("OLLAMA_API_KEY does not start with sk-")
+    
+    # MODIFIED: Create messages list for chat endpoint instead of single prompt
+    system_message = {
+        "role": "system",
+        "content": general_prompt
+    }
+    
+    # Discuss if we want to attach the image every time
+    user_message = {
+        "role": "user",
+        "content": user_prompt,
+        "images": [graphic_b64]
+    }
+    
+    # ADDED: Retrieve existing conversation history or create new one
+    if request_uuid in conversation_history:
+        # Add new user message
+        conversation_history[request_uuid]['messages'].append(user_message)
+        conversation_history[request_uuid]['last_updated'] = timestamp
+    else:
+        # Start a new conversation with system and user messages
+        conversation_history[request_uuid] = {
+            'messages': [system_message, user_message],
+            'last_updated': timestamp
+        }
 
+    # ADDED: use history for the request
+    messages = conversation_history[request_uuid]['messages'][-MAX_HISTORY_LENGTH:]
+
+    # ADDED: Create log-friendly version of messages without full base64 content
+    log_friendly_messages = []
+    for msg in messages:
+        log_msg = msg.copy()  # Create a copy to avoid modifying the original
+        if 'images' in log_msg:
+            # Replace image content with placeholder or truncate it
+            log_msg['images'] = [f"[BASE64_IMAGE:{len(img)} bytes]" for img in log_msg['images']]
+        log_friendly_messages.append(log_msg)
+
+    logging.debug(f"Message history: {log_friendly_messages}")
+
+    # MODIFIED: Create request data for chat endpoint
     request_data = {
         "model": ollama_model,
-        "prompt": prompt,
-        "images": [graphic_b64],
+        "messages": messages,
         "stream": False,
         "temperature": 0.0,
-        "format": "json",
+        "format": {
+            "type": "object",
+            "properties": {
+                "response_brief": {
+                    "type": "string"
+                },
+                "response_full": {
+                    "type": "string"
+                }
+                },
+                "required": [
+                    "age",
+                    "available"
+                    ]
+        },
         "keep_alive": -1  # keep model loaded in memory indefinitely
     }
+
     logging.debug("serializing json from request_data dictionary")
     request_data_json = json.dumps(request_data)
 
@@ -157,10 +248,25 @@ def followup():
         ollama_error_msg = None
         try:
             # strip() at end since llama often puts a newline before json
-            response_text = json.loads(response.text)['response'].strip()
+            response_text = json.loads(response.text)['message']['content'].strip() # MODIFIED: text is located in message.content in the /chat response
             if log_pii:
                 logging.debug("raw ollama response: " + response_text)
             followup_response_json = json.loads(response_text)
+            
+            # ADDED: Format assistant response for history
+            assistant_message = {
+                "role": "assistant",
+                "content": response_text
+            }
+
+            # ADDED: Update conversation history
+            conversation_history[request_uuid]['messages'].append(assistant_message)
+            conversation_history[request_uuid]['last_updated'] = timestamp
+
+            # Add debug logging
+            logging.debug(f"Conversation history status: UUID {request_uuid} {'updated' if request_uuid in conversation_history else 'created'}")
+            logging.debug(f"History now contains {len(conversation_history)} conversation(s)")
+
         except json.JSONDecodeError:
             ollama_error_msg = "raw response does not look like json"
         except KeyError:
@@ -214,6 +320,44 @@ def followup():
     return response
 
 
+# ADDED: New endpoint to clear history for a specific request_uuid
+@app.route("/clear-history/<request_uuid>", methods=["GET"])
+def clear_history(request_uuid):
+    """
+    Clear conversation history for a specific request_uuid
+    """
+    logging.info(f"Request to clear history for {request_uuid}")
+    logging.info(f"Before clearing: {len(conversation_history)} conversations in memory")
+    logging.info(f"UUID exists in history: {request_uuid in conversation_history}")
+    
+    if request_uuid in conversation_history:
+        del conversation_history[request_uuid]
+        logging.info(f"After clearing: {len(conversation_history)} conversations in memory")
+        return jsonify({
+            "status": "success",
+            "message": f"History for {request_uuid} cleared"
+        }), 200
+    else:
+        logging.info("UUID not found in history")
+        return jsonify({
+            "status": "not_found",
+            "message": f"No history found for {request_uuid}"
+        }), 404
+
+
+# ADDED: New endpoint to get conversation statistics
+@app.route("/history-stats", methods=["GET"])
+def history_stats():
+    """
+    Get statistics about stored conversation histories
+    """
+    return jsonify({
+        "active_conversations": len(conversation_history),
+        "oldest_conversation": min([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None,
+        "newest_conversation": max([h['last_updated'] for h in conversation_history.values()]) if conversation_history else None
+    }), 200
+
+
 @app.route("/health", methods=["GET"])
 def health():
     """
@@ -227,4 +371,4 @@ def health():
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)
-    followup()
+    # followup() - not needed


### PR DESCRIPTION
With us moving from the `/generate` to the `/chat` endpoint in the `text-followup` preprocessor, we can no longer use an existing Ollama endpoint specified in our config.

In this PR I changed the endpoints in the `content-categoriser` and `graphic-caption` preprocessor to accommodate the change in the base API route.

Steps to take to retain full system functionality:
1. Manually change the endpoint in `/var/docker/image/config/ollama.env` from `https://ollama.pegasus.cim.mcgill.ca/ollama/api/generate` to `https://ollama.pegasus.cim.mcgill.ca/ollama/api` (I believe I can't include this file in my commit).
2. Merge this PR.
3. Merge #972 

This will ensure the uniformity between routes (base route + preprocessor-specific endpoint).

Tested: new `f"{os.environ['OLLAMA_URL']}/generate" ` == old `os.environ['OLLAMA_URL']`

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
