### PR TITLE
fix: Include followup query in cache key

### DIFF
--- a/orchestrator/src/server-cache.ts
+++ b/orchestrator/src/server-cache.ts
@@ -18,6 +18,12 @@
 import { Client } from "memjs";
 import hash from "object-hash";
 
+interface CacheValue {
+    reqData: string | object;
+    preprocessor: string; 
+    followupQuery?: string 
+}
+
 /** Server cache implementation for IMAGE based on memjs :  https://memjs.netlify.app/ */
 export class ServerCache {
     memjsClient : Client;
@@ -44,7 +50,7 @@ export class ServerCache {
         }
     }
     
-    constructCacheKey(data: Record<string, unknown>, preprocessor: string): string{
+    constructCacheKey(data: Record<string, any>, preprocessor: string): string{
         // const reqCapabilities = data["capabilities"] as string[];
         // const isDebugMode = reqCapabilities && reqCapabilities.includes("ca.mcgill.a11y.image.capability.DebugMode");
         let reqData : string | object = "";
@@ -57,7 +63,10 @@ export class ServerCache {
         } else if(data["highChartsData"]){
             reqData = data["highChartsData"] as object;
         }
-        const cacheKeyData = {"reqData": reqData, "preprocessor": preprocessor}
+        const cacheKeyData: CacheValue  = { reqData: reqData, preprocessor: preprocessor };
+        if(data["followup"] && data["followup"]["query"]){
+            cacheKeyData["followupQuery"] = data["followup"]["query"] as string;
+        }
         return hash(cacheKeyData);
     }
 }


### PR DESCRIPTION
The PR provides fix for issue: https://github.com/Shared-Reality-Lab/IMAGE-server/issues/982. 
The fix is to include followup query in the hashkey. Without this, stale data was wrongly served from the cache. After the fix, when the cache is enabled the preprocessor gives different responses for the same graphic (depending on followup query).

Before Fix:
![image](https://github.com/user-attachments/assets/bd36e039-d81d-44a1-a2d1-92578da1edda)

After Fix:
![image](https://github.com/user-attachments/assets/19d294e2-fba1-41cd-8f17-89737f5e9abd)


---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
