### PR TITLE
Genericize PAH rendering names

### DIFF
--- a/handlers/photo-audio-handler/src/server.ts
+++ b/handlers/photo-audio-handler/src/server.ts
@@ -133,9 +133,6 @@ app.post("/handler", async (req, res) => {
         }
     }
 
-    // Generate rendering title
-    const renderingTitle = utils.renderingTitle(semseg, objDet, objGroup);
-
     // Handle language if targetLanguage is not English
     if (targetLanguage != "en") {
         console.debug(`Translating ttsData values to ${targetLanguage}"`);
@@ -160,7 +157,7 @@ app.post("/handler", async (req, res) => {
         const textString = ttsData.map(x => x["value"]).join(" ");
         const rendering = {
             "type_id": "ca.mcgill.a11y.image.renderer.Text",
-            "description": renderingTitle + " (text only)",
+            "description": "Text description",
             "data": { "text": textString }
         };
         if (ajv.validate("https://image.a11y.mcgill.ca/renderers/text.schema.json", rendering["data"])) {
@@ -234,7 +231,7 @@ app.post("/handler", async (req, res) => {
                     console.debug("Constructing segment audio rendering")
                     const rendering = {
                         "type_id": "ca.mcgill.a11y.image.renderer.SegmentAudio",
-                        "description": renderingTitle,
+                        "description": "Rich audio description",
                         "data": {
                             "audioFile": dataURL,
                             "audioInfo": segArray
@@ -253,7 +250,7 @@ app.post("/handler", async (req, res) => {
                     console.debug("Constructing simple audio rendering")
                     const rendering = {
                         "type_id": "ca.mcgill.a11y.image.renderer.SimpleAudio",
-                        "description": renderingTitle,
+                        "description": "Rich audio description",
                         "data": {
                             "audio": dataURL
                         },
@@ -286,22 +283,22 @@ app.post("/handler", async (req, res) => {
     }
 
     // Translate renderings' description before sending response
-	if (targetLanguage !== "en") {
-		try {
-			console.debug("Translating renderings description to " + targetLanguage);
-			const translatedDesc = await utils.getTranslationSegments(
+    if (targetLanguage !== "en") {
+        try {
+            console.debug("Translating renderings description to " + targetLanguage);
+            const translatedDesc = await utils.getTranslationSegments(
                             renderings.map(x => x["description"]),
                             targetLanguage
                         );
 
-			for (let i = 0; i < renderings.length; i++) {
-				renderings[i]["description"] = translatedDesc[i];
-			}
-		} catch(e) {
-			console.error("Failed to translate rendering descriptions to " + targetLanguage);
-			console.error(e);
-		}
-	}
+            for (let i = 0; i < renderings.length; i++) {
+                renderings[i]["description"] = translatedDesc[i];
+            }
+        } catch(e) {
+            console.error("Failed to translate rendering descriptions to " + targetLanguage);
+            console.error(e);
+        }
+    }
     // Send response
 
     const response = utils.generateEmptyResponse(req.body["request_uuid"]);

--- a/handlers/photo-audio-handler/src/utils.ts
+++ b/handlers/photo-audio-handler/src/utils.ts
@@ -143,7 +143,7 @@ export function generateActions(objs: Obj[], group: number[], actionRec: Action)
         const act = actionRec["actions"].find((x: { "personID": number }) => x["personID"] === id);
         if (act !== undefined) {
             const label = act["action"].trim();
-            if (act["confidence"] < ACT_THRES) { 
+            if (act["confidence"] < ACT_THRES) {
                 if (maybeActions[label]) {
                     maybeActions[label].push(id);
                 }
@@ -158,9 +158,9 @@ export function generateActions(objs: Obj[], group: number[], actionRec: Action)
         }
         else {
             other.push(id);
-        } 
+        }
     }
-    
+
     for (const label in actions) {
         const len = actions[label].length;
         const pType = len > 1 ? "people" : "person";
@@ -172,7 +172,7 @@ export function generateActions(objs: Obj[], group: number[], actionRec: Action)
             "label": pType + " " + actionTxt,
             "value": len.toString() + " " + pType + " " + actionTxt + ","
         };
-        objects.push(object);       
+        objects.push(object);
     }
     for (const label in maybeActions) {
         const len = maybeActions[label].length;
@@ -184,7 +184,7 @@ export function generateActions(objs: Obj[], group: number[], actionRec: Action)
             "objects": acts,
             "value": len.toString() + " " + pType + " who might be " + actionTxt + ","
         };
-        objects.push(object);       
+        objects.push(object);
     }
     if (other.length > 0) {
         const len = other.length;
@@ -307,7 +307,7 @@ export async function getTTS(text: string[], language: string): Promise<TTSRespo
         console.error(`photo-audio-handler doesn't support '${language}' language`);
         throw new Error("Unable to send segment to TTS");
     }
-    
+
     return fetch(serviceURL, {
       method: "POST",
       headers: {
@@ -374,19 +374,4 @@ export async function sendOSC(jsonFile: string, outFile: string, server: string,
             }, 5000);
         })
     ]);
-}
-
-export function renderingTitle(semseg: { "segments": Record<string, unknown>[] }, objDet: ObjDet, objGroup: ObjGroup): string {
-    console.debug("Rendering title")
-    const hasSemseg = (semseg !== undefined) && (semseg["segments"].length > 0);
-    const hasObj = (objDet !== undefined) && (objGroup !== undefined) && (objDet["objects"].length > 0);
-    if (hasSemseg && hasObj) {
-        return "Regions, things, and people";
-    }
-    else if (hasSemseg) {
-        return "Outlines of regions";
-    }
-    else {
-        return "Things and people";
-    }
 }


### PR DESCRIPTION
Resolve #961 by setting the name for text outputs of the photo audio handler to "Text description" and audio outputs of the photo audio handler to "Rich audio description". Checked names by running on unicorn and verifying outputs were unchanged except for the title of the rendering.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
