### PR TITLE
Fix map-tactile-svg-hadnler to work for placeId and unexpected crossing types

### DIFF
--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -496,7 +496,7 @@ def getMidpoint(contents):
 
     # Convert degrees to radians
     lat1, lon1, lat2, lon2 = map(math.radians,
-                                 [lat["min"], lon["min"], 
+                                 [lat["min"], lon["min"],
                                   lat["max"], lon["max"]])
 
     # Convert to Cartesian coordinates

--- a/handlers/map-tactile-svg/map-svg.py
+++ b/handlers/map-tactile-svg/map-svg.py
@@ -495,14 +495,14 @@ def getMidpoint(contents):
     lon = data["bounds"]["longitude"]
 
     # Convert degrees to radians
-    lat1, lon1, lat2, lon2 = map(math.radians, 
+    lat1, lon1, lat2, lon2 = map(math.radians,
                                  [lat["min"], lon["min"], 
                                   lat["max"], lon["max"]])
 
     # Convert to Cartesian coordinates
-    x1, y1, z1 = (math.cos(lat1) * math.cos(lon1), 
+    x1, y1, z1 = (math.cos(lat1) * math.cos(lon1),
                   math.cos(lat1) * math.sin(lon1), math.sin(lat1))
-    x2, y2, z2 = (math.cos(lat2) * math.cos(lon2), 
+    x2, y2, z2 = (math.cos(lat2) * math.cos(lon2),
                   math.cos(lat2) * math.sin(lon2), math.sin(lat2))
 
     # Compute the midpoint in Cartesian coordinates


### PR DESCRIPTION
Earlier map-tactile-svg-handler did not work with placeId as it always expected coordinates to be present in the request. Changes have been made to calculate the central coordinates using the coordinates of the bounds when placeId is passed by the request. 

The 'spherical midpoint formula' is employed instead of simply averaging the latitude and longitude. While this currently makes little difference (except for minor rounding errors produced ) the results of simple averaging are likely to be increasingly inaccurate if we use larger bounds. Hence, the more complicated but scalable 'spherical midpoint formula' was adopted.

Testing:
1. Rendering description and logs of map centered at Smithsonian American Art Museum (as per Google) using placeID (38.897893,-77.023069):
`Tactile rendering of map centered at latitude 38.897893 and longitude -77.023069`
```
map-tactile-svg-handler-1         | DEBUG:root:Received request
map-tactile-svg-handler-1         | DEBUG:root:Coordinates not found in request. Calculating midpoint from bounds.
map-tactile-svg-handler-1         | DEBUG:root:Sending response
```
2. Rendering description of map centered at Smithsonian American Art Museum (as per Google) using coordinates (38.897893,-77.023069):
`Tactile rendering of map centered at Smithsonian Institute Donald W. Reynolds Center for American Art and Portraiture`
(This is the tag of these coordinates on OSM)
```
map-tactile-svg-handler-1         | DEBUG:root:Received request
map-tactile-svg-handler-1         | DEBUG:root:Coordinates found in request
map-tactile-svg-handler-1         | DEBUG:root:Sending response
```
3. Rendering description of map centered (as per OSM) at Smithsonian American Art Museum using coordinates (38.8978665,-77.0235904):
`Tactile rendering of map centered at Smithsonian American Art Museum`
```
map-tactile-svg-handler-1         | DEBUG:root:Received request
map-tactile-svg-handler-1         | DEBUG:root:Coordinates found in request
map-tactile-svg-handler-1         | DEBUG:root:Sending response
```
Note that the familiar name is only returned in cases where the coordinates are present because nominatim preprocessor does not return results for placeId.

While testing for this location another minor bug was discovered which has also been fixed in the same PR. In the earlier implementation it was assumed that if the category of a point was "crossing" a key "crossing" would exist in the JSON. However, this is not the case and changes have been made to account for this. In the absence of additional information regarding a "crossing" the label now says Crossing as shown below:
![image](https://github.com/user-attachments/assets/17ef627f-d416-47c1-b9f0-341778e5d649)



This PR fixes #985.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
