### PR TITLE
restoreunstable: git reset --hard; finds containers with image in name

### DIFF
--- a/scripts/restoreunstable
+++ b/scripts/restoreunstable
@@ -70,7 +70,9 @@ git remote set-url origin "$GIT_REMOTE"
 # Even though we pull already built docker images, keep the repo up to date
 # and sync up to any config directory changes.
 git checkout main
-# `could git reset --hard` here, but should probably just error out and let user deal with it
+# reset --hard and pull to make sure that we have a clean version of what is in main
+git fetch origin
+git reset --hard origin/main
 git pull
 git submodule update --init
 
@@ -86,6 +88,14 @@ docker compose down
 
 echo "about to stop all containers on image network..."
 IMAGECONTAINERS=$(docker ps -q -f "network=image")
+if [[ ${IMAGECONTAINERS} ]]; then
+    docker stop $IMAGECONTAINERS
+    docker container rm $IMAGECONTAINERS
+fi
+
+echo "about to find all containers with \"image\" in name, e.g., monarch link app and TAT"
+# https://github.com/Shared-Reality-Lab/IMAGE-server/issues/987
+IMAGECONTAINERS=$(docker container ls -q --filter name=image)
 if [[ ${IMAGECONTAINERS} ]]; then
     docker stop $IMAGECONTAINERS
     docker container rm $IMAGECONTAINERS


### PR DESCRIPTION
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

fixes #987. This PR adds two things to the `restoreunstable` script:
1. `git reset --hard` to ensure that any local changes are wiped out, and we have a pure `main` pull without errors
2. additional check in script to find all containers with `image` in name, and stop/rm them as well.

Testing:
- jeff ran script to make sure it still brings things down and up as before
- @VenissaCarolQuadros put monarch-link-app in bad state (404 when accessing, as described in #987), and ran the revised script to make sure it killed redundant container(s) and put the monarch-link-app back in a working state with traefik.

Assigning to @shahdyousefak for review + flagging potential merge issues with changes she is working on to change this to `imageup`

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
