### PR TITLE
Changing the restart policy to never

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   orchestrator:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-orchestrator:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     environment:
       - PARALLEL_PREPROCESSORS=ON
       - STORE_IMAGE_DATA=ON
@@ -27,7 +27,7 @@ services:
   espnet-tts:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-service-espnet-tts:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     environment:
       - TORCH_DEVICE=cuda
     labels:
@@ -42,7 +42,7 @@ services:
   espnet-tts-fr:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-service-espnet-tts-fr:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     environment:
       - TORCH_DEVICE=cuda
     labels:
@@ -57,7 +57,7 @@ services:
   multilang-support:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-service-translation:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.cacheTimeout: 3600
     deploy:
@@ -70,7 +70,7 @@ services:
   autour-preprocessor:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-autour:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/maps.env
     labels:
@@ -83,7 +83,7 @@ services:
   content-categoriser:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-content-categoriser:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 1
       ca.mcgill.a11y.image.port: 5000
@@ -96,7 +96,7 @@ services:
   graphic-caption:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-graphic-caption:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 1
       ca.mcgill.a11y.image.port: 5000
@@ -109,7 +109,7 @@ services:
   text-followup:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-text-followup:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     environment:
       - MAX_HISTORY_LENGTH=100
       - HISTORY_EXPIRY=3600
@@ -125,7 +125,7 @@ services:
   graphic-tagger:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-graphic-tagger:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/azure-api.env
     labels:
@@ -138,7 +138,7 @@ services:
   object-detection:
     profiles: [production, default, test]
     image: ghcr.io/shared-reality-lab/image-preprocessor-object-detection-yolo:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 3
       ca.mcgill.a11y.image.port: 5000
@@ -158,7 +158,7 @@ services:
   object-grouping:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-grouping:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 4
       ca.mcgill.a11y.image.port: 5000
@@ -169,7 +169,7 @@ services:
   openstreetmap:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-openstreetmap:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/maps.env
     labels:
@@ -182,7 +182,7 @@ services:
   object-sorting:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-sorting:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 5
       ca.mcgill.a11y.image.port: 5000
@@ -193,7 +193,7 @@ services:
   semantic-segmentation:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-mmsemantic-segmentation:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     deploy:
       resources:
         reservations:
@@ -211,7 +211,7 @@ services:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-service-supercollider:${REGISTRY_TAG}
     command: sclang -D ./loader.scd
-    restart: unless-stopped
+    restart: never
     volumes:
       - sc-store:/tmp/sc-store
     deploy:
@@ -222,7 +222,7 @@ services:
   photo-audio-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-photo-audio:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     labels:
@@ -235,7 +235,7 @@ services:
   autour-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-autour:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     labels:
@@ -248,7 +248,7 @@ services:
   photo-audio-haptics-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-photo-audio-haptics:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     labels:
@@ -261,7 +261,7 @@ services:
   high-charts-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-high-charts:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     labels:
@@ -274,7 +274,7 @@ services:
   svg-od-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-svg-od:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
     environment:
@@ -283,7 +283,7 @@ services:
   svg-semantic-seg-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-svg-semantic-seg:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
     environment:
@@ -292,7 +292,7 @@ services:
   depth-map-generator:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-depth-map-generator:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     deploy:
       resources:
         reservations:
@@ -309,7 +309,7 @@ services:
   svg-depth-map:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-svg-depth-map:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
     environment:
@@ -318,7 +318,7 @@ services:
   nominatim-preprocessor:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-nominatim:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
         - ./config/express-common.env
     labels:
@@ -330,7 +330,7 @@ services:
   photo-tactile-svg-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-photo-tactile-svg:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
     environment:
@@ -339,7 +339,7 @@ services:
   map-tactile-svg-handler:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-handler-map-tactile-svg:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
     environment:
@@ -348,7 +348,7 @@ services:
   text-followup-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-text-followup:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
         ca.mcgill.a11y.image.route: "followup"
@@ -362,7 +362,7 @@ services:
   motd-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-motd:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     environment:
@@ -374,7 +374,7 @@ services:
   hello-haptics-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-hello-haptics:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/express-common.env
     labels:
@@ -386,7 +386,7 @@ services:
   ocr-clouds-preprocessor:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-ocr-clouds:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
       - ./config/apis-and-selection.env
     labels:
@@ -399,7 +399,7 @@ services:
   object-depth-calculator:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-object-depth-calculator:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 4
       ca.mcgill.a11y.image.port: 5000
@@ -410,7 +410,7 @@ services:
   line-charts:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-line-charts:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.preprocessor: 1
       ca.mcgill.a11y.image.port: 5000
@@ -421,7 +421,7 @@ services:
   action-recognition:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-action-recognition:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.preprocessor: 4
         ca.mcgill.a11y.image.port: 5000
@@ -438,7 +438,7 @@ services:
   ocr-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-ocr:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
       ca.mcgill.a11y.image.handler: enable
     environment:
@@ -447,7 +447,7 @@ services:
   osm-streets-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-osm-streets:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     env_file:
         - ./config/express-common.env
     depends_on:
@@ -463,7 +463,7 @@ services:
   svg-open-street-map-handler:
     profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-svg-open-street-map:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.handler: enable
         ca.mcgill.a11y.image.port: 5000
@@ -473,7 +473,7 @@ services:
   collage-detector-preprocessor:
     profiles: [production, test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-collage-detector:${REGISTRY_TAG}
-    restart: unless-stopped
+    restart: never
     labels:
         ca.mcgill.a11y.image.preprocessor: 1
         ca.mcgill.a11y.image.port: 5000
@@ -492,14 +492,14 @@ services:
   monarch-link-app:
     profiles: [test, default]
     image: "ghcr.io/shared-reality-lab/image-service-monarch-link-app:${REGISTRY_TAG}"
-    restart: unless-stopped
+    restart: never
     networks:
       - traefik
   
   tat:
     profiles: [test, default]
     image: "ghcr.io/shared-reality-lab/image-service-tat:${REGISTRY_TAG}"
-    restart: unless-stopped
+    restart: never
     networks:
       - traefik
 # end - unicorn exclusive services        


### PR DESCRIPTION
Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

If a container fails or exits, Docker automatically restarts it: if something is fundamentally wrong (bad env, missing dependency, etc.), Docker will keep restarting endlessly.  It may flood the logs with retries as well, making it harder to discern what went wrong.
--> container status becomes: restarting, restarting, restarting

With the `never` restart policy, Docker will not auto-restart the container, i.e, If the container crashes, it stays in the exited state. This way, by switching to `restart: never`, if a container: crashes at startup, fails health check, down/exits with error, this will make container failures more visible and deterministic. It stays down, and our health check will correctly report it its unhealthy/not running status.

Once we have verified this, we intend to deploy this setup to Pegasus. This will be beneficial, since container flapping and lack-of-visibility is not ideal in production.

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
