### PR TITLE
Update graphic-caption and text-followup Llama prompts

### DIFF
--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -29,8 +29,16 @@ configure_logging()
 app = Flask(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
+PROMPT = """
+Give a detailed description of the style, content,
+and the most significant aspects of this image.
+Answer with maximum one sentence.
+"""
 
-@app.route("/preprocessor", methods=['POST', ])
+logging.debug(f"Graphic caption prompt: {PROMPT}")
+
+
+@app.route("/preprocessor", methods=['POST'])
 def categorise():
     logging.debug("Received request")
 
@@ -90,13 +98,9 @@ def categorise():
         logging.warn("OLLAMA_API_KEY usually starts with sk-, "
                      "but this one starts with: " + api_key[:3])
 
-    prompt = "I am blind, so I cannot see this image. " \
-             "Tell me the most important aspects of it, including " \
-             "style, content, and the most significant aspect of the image." \
-             "Answer with maximum one sentence. "
     request_data = {
         "model": ollama_model,
-        "prompt": prompt,
+        "prompt": PROMPT,
         "images": [graphic_b64],
         "stream": False,
         "temperature": 0.0,
@@ -165,4 +169,3 @@ def health():
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)
-    categorise()

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -134,31 +134,30 @@ def followup():
     # TODO: add previous request history before new prompt
 
     # default prompt, which can be overriden by env var just after
-    general_prompt = ("""
-              I am blind so I cannot see this image.
+    general_prompt = """
+              The user cannot see this image. Answer user's question about it.
               Answer in a single JSON object containing two keys.
-              The first key is "response_brief" and is a single sentence
-              that can stand on its own that directly answers the specific
-              request at the end of this prompt.
-              The second key is "response_full" and provides maximum
+              The first key is "response_brief" and its value is a single
+              sentence that can stand on its own. It directly answers the
+              specific request at the end of this prompt.
+              The second key is "response_full" and its value provides maximum
               three sentences of additional detail,
               without repeating the information in the first key.
               If there is no more detail you can provide,
-              omit the second key instead of having an empty key.
-              Remember to answer only in JSON, or I will be very angry!
+              omit the "response_full" key instead of having an empty key.
+              IMPORTANT: answer only in JSON.
               Do not put anything before or after the JSON,
               and make sure the entire response is only a single JSON block,
               with both keys in the same JSON object.
               Here is an example of the output JSON in the format you
               are REQUIRED to follow:
               {
-                "response_brief": "One sentence response to the user request",
-                "response_full": "Further details."
+                "response_brief": "One sentence response to the user request.",
+                "response_full": "Further details. Maximum three sentences."
               }
               Note that the first character of output MUST be "{".
               Remove all whitespace before and after the JSON.
-              Here is my request:
-              """)
+              """
     # override with prompt from environment variable only if it exists
     general_prompt = os.getenv('TEXT_FOLLOWUP_PROMPT_OVERRIDE', general_prompt)
     user_prompt = content["followup"]["query"]


### PR DESCRIPTION
Updated LLaMa prompts to improve the functionality and remove bias.

Problem:
![image](https://github.com/user-attachments/assets/4bc1c683-3dc4-45d2-a21a-a7cc3201b796)

Fix: remove the mention of the user's blindness and move towards the generalized request ("the user cannot see this image" and "give a detailed description").

Tested by running the extension (for `graphic-caption`) and with jQuery (for `text-followup`).

To Do: continuously monitor model outputs for further improvement.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
