### PR TITLE
Improve handler error reporting in the orchestrator

### DIFF
--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -396,7 +396,7 @@ app.post("/render", (req: express.Request, res: express.Response) => {
                     if (resp.ok) {
                         return resp.json() as Promise<HandlerResponse>;
                     } else {
-                        console.error(`${resp.status} ${resp.statusText}`);
+                        console.error(`Received ${resp.status} ${resp.statusText} from ${handler[0]}.`);
                         const result = await resp.json();
                         throw result;
                     }


### PR DESCRIPTION
As mentioned in #1010, the current way that the orchestrator reports HTTP error codes returned by handlers suggests that the orchestrator itself is experiencing the error. This updates the log line to clearly indicate which handler the error code originates in. For example:
```
orchestrator-1  | Waiting for handlers...
orchestrator-1  | Received 500 INTERNAL SERVER ERROR from svg-od-handler.
orchestrator-1  | Failed to validate the response renderer
orchestrator-1  | Valid response generated.
```
Previously the line would read "500 INTERNAL SERVER ERROR".

Tested with sample graphics on unicorn and there does not appear to be any regression from current main. Assigning to @jeffbl for feedback on the error message before merging.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
