### PR TITLE
Prod deploy

### DIFF
--- a/.github/workflows/tat-service.yml
+++ b/.github/workflows/tat-service.yml
@@ -76,3 +76,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REGISTRY_TAG=${{ env.REGISTRY_TAG }}

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -41,3 +41,21 @@ services:
     volumes:
       - website-logs:/srv/logs:ro
       - ./goaccess_report:/srv/report
+
+  monarch-link-app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.monarch-link-app.rule=Host(`monarch.image.a11y.mcgill.ca`)"
+      - "traefik.http.routers.monarch-link-app.tls.certresolver=myresolver"
+      - traefik.docker.network=traefik
+    environment:
+      - SERVER_NAME=image.a11y.mcgill.ca
+
+  tat:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tat.rule=Host(`tat.image.a11y.mcgill.ca`)"
+      - "traefik.http.routers.tat.tls.certresolver=myresolver"
+      - traefik.docker.network=traefik
+    environment:
+      - SERVER_NAME=image.a11y.mcgill.ca

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -45,7 +45,9 @@ services:
   monarch-link-app:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.monarch-link-app.rule=Host(`monarch.image.a11y.mcgill.ca`)"
+      - "traefik.http.routers.monarch-link-app.rule=Host(`image.a11y.mcgill.ca`) && PathPrefix(`/monarch`)"
+      - "traefik.http.middlewares.monarch-stripprefix.stripprefix.prefixes=/monarch"
+      - "traefik.http.routers.monarch-link-app.middlewares=monarch-stripprefix@docker"
       - "traefik.http.routers.monarch-link-app.tls.certresolver=myresolver"
       - traefik.docker.network=traefik
     environment:
@@ -54,7 +56,10 @@ services:
   tat:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.tat.rule=Host(`tat.image.a11y.mcgill.ca`)"
+      - "traefik.http.routers.tat.rule=Host(image.a11y.mcgill.ca) && PathPrefix(/tat)"
+      - "traefik.http.routers.tat.tls.certresolver=myresolver"
+      - "traefik.http.middlewares.tat-stripprefix.stripprefix.prefixes=/tat"
+      - "traefik.http.routers.tat.middlewares=tat-stripprefix@docker"
       - "traefik.http.routers.tat.tls.certresolver=myresolver"
       - traefik.docker.network=traefik
     environment:

--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -1,16 +1,17 @@
+ARG REGISTRY_TAG
 # Stage 1: Build the application
-FROM node:20-alpine AS build
+FROM ghcr.io/shared-reality-lab/tat-service:${REGISTRY_TAG} as build
 
 # Set the working directory inside the container
 WORKDIR /app
 
 # Clone git repo into app dir
-RUN apk add git
-RUN git clone https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring.git \
-    --depth 1 --single-branch .
+# RUN apk add git
+# RUN git clone https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring.git \
+#     --depth 1 --single-branch .
 
 # Install dependencies
-RUN npm install
+# RUN npm install
 
 
 # Build the application

--- a/test-docker-compose.yml
+++ b/test-docker-compose.yml
@@ -101,7 +101,9 @@ services:
   monarch-link-app:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.monarch-link-app.rule=Host(`monarch.unicorn.cim.mcgill.ca`)"
+      - "traefik.http.routers.monarch-link-app.rule=Host(`unicorn.cim.mcgill.ca`) && PathPrefix(`/image/monarch`)"
+      - "traefik.http.middlewares.monarch-link-app-stripprefix.stripprefix.prefixes=/image/monarch"
+      - "traefik.http.routers.monarch-link-app.middlewares=monarch-link-app-stripprefix@docker"
       - "traefik.http.routers.monarch-link-app.tls.certresolver=myresolver"
       - traefik.docker.network=traefik
     environment:
@@ -110,7 +112,9 @@ services:
   tat:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.tat.rule=Host(`tat.unicorn.cim.mcgill.ca`)"
+      - "traefik.http.routers.tat.rule=Host(`unicorn.cim.mcgill.ca`) && PathPrefix(`/image/tat`)"
+      - "traefik.http.middlewares.tat-stripprefix.stripprefix.prefixes=/image/tat"
+      - "traefik.http.routers.tat.middlewares=tat-stripprefix@docker"
       - "traefik.http.routers.tat.tls.certresolver=myresolver"
       - traefik.docker.network=traefik
     environment:


### PR DESCRIPTION
This PR makes the following changes for deploying the TAT and monarch-link-service to production:

1. Modifies the tat Dockerfile to build from image in ghcr (Pushed by workflow in https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring)
2. Modifies the paths in test docker-compose to use paths instead of subdomains for both tat (https://unicorn.cim.mcgill.ca/image/tat/) and monarch-link-app (https://unicorn.cim.mcgill.ca/image/monarch/)
3. Adds new entries to the prod docker-compose to create equivalent paths for tat and monarch-link-app in production

This addresses the first item in #1003.


---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
