### PR TITLE
Add new schema for linked/ cyclic textbook diagrams

### DIFF
--- a/preprocessors/textbook-diagram.schema.json
+++ b/preprocessors/textbook-diagram.schema.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/preprocessors/textbook-diagram.schema.json",
+    "type": "object",
+    "title": "Textbook Diagram Data",
+    "description": "JSON containing pixel coordinates of different segments in a textbook diagram and the links between them",
+    "definitions": {
+        "normCoord": {
+            "description": "A pair of normalized coordinates.",
+            "type": "array",
+            "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+            },
+            "minItems": 2,
+            "maxItems": 2
+        },
+        "contour": {
+            "type": "object",
+            "description": "A single contour of a segment as detected. Each contour is a separate region.",
+            "properties": {
+                "coordinates": {
+                    "description": "The normalized coordinates forming the contour as returned by OpenCV.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/normCoord"
+                    }
+                },
+                "centroid": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/normCoord"
+                        },
+                        {
+                            "description": "The center of the contour with normalized coordinates."
+                        }
+                    ]
+                },
+                "area": {
+                    "description": "The area of the image taken by this contour",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        }
+    },
+    "properties": {
+        "nodes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "A stage in the flow diagram",
+                "properties": {
+                    "segments": {
+                        "type": "array",
+                        "description": "Divides the entire stage into different segments where each segment indicates a noteworthy region or structure.",
+                        "items": {
+                            "type": "object",
+                            "description": "Contains information about each individual segment in the stage. Information such as area, centre of segment etc are included in this section",
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the segment.",
+                                    "type": "string"
+                                },
+                                "contours": {
+                                    "description": "The separate contours making up the segment.",
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/contour"
+                                    }
+                                },
+                                "centroid": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/definitions/normCoord"
+                                        },
+                                        {
+                                            "description": "The overall centroid of the segment with normalized coordinates."
+                                        }
+                                    ]
+                                },
+                                "area": {
+                                    "description": "Total area occupied by the segment in a given stage. the area is normalised between 0 and 1",
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "contours",
+                                "centroid",
+                                "area"
+                            ]
+                        }
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the stage"
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Name of the stage"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "One/ two sentence description of the stage"
+                    }
+                },
+                "required": [
+                    "id",
+                    "label",
+                    "segments"
+                ]
+            }
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "Links between the various nodes based on the arrow directions",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "id of the node at which the link starts. Randomly chosen if the arrow is bidirectional"
+                    },
+                    "target": {
+                        "type": "string",
+                        "description": "id of the node at which the link ends. Randomly chosen if the arrow is bidirectional"
+                    },
+                    "directed": {
+                        "type": "boolean",
+                        "description": "true indicates that the link is unidirectional"
+                    }
+                },
+                "required": [
+                    "source",
+                    "target",
+                    "directed"
+                ]
+            }
+        }
+    },
+    "required": [
+        "nodes",
+        "links"
+    ]
+}

--- a/preprocessors/textbook-diagram.schema.json
+++ b/preprocessors/textbook-diagram.schema.json
@@ -61,7 +61,7 @@
                             "description": "Contains information about each individual segment in the stage. Information such as area, centre of segment etc are included in this section",
                             "properties": {
                                 "name": {
-                                    "description": "The name of the segment.",
+                                    "description": "The name of the segment. Provides additional detail regarding subsections of a stage, if present.",
                                     "type": "string"
                                 },
                                 "contours": {
@@ -89,7 +89,6 @@
                                 }
                             },
                             "required": [
-                                "name",
                                 "contours",
                                 "centroid",
                                 "area"


### PR DESCRIPTION
This PR adds a new schema for the textbook diagram preprocessor to be created in #872.

We are targeting to handle linked/ cyclic textbook diagrams (examples provided in the issue) for this schema
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
