### PR TITLE
Running Handlers once they're ready

### DIFF
--- a/orchestrator/src/docker.ts
+++ b/orchestrator/src/docker.ts
@@ -53,8 +53,7 @@ export function getFilteredContainers(containers: Docker.ContainerInfo[]) : Dock
         return isInTargetNetwork;
     });
     //Only return the containers that are running 
-    return filteredContainers.filter(c => c.State === "running");
-    
+    return filteredContainers.filter(c => c.State === "running");  
 }
 
 function isPartOfRoute(container: Docker.ContainerInfo, route: string) {

--- a/orchestrator/src/docker.ts
+++ b/orchestrator/src/docker.ts
@@ -124,72 +124,64 @@ export function getHandlerServices(containers: Docker.ContainerInfo[], route: st
 }
 
 //Returns the optional preprocessors/handlers needed for the given preprocessor/handler to run 
-//Optional preprocessors: enhance functionality but are not strictly required for execution.
-export function getOptional(containers: Docker.ContainerInfo[], preprocessorName: string, preprocessors: (string | number)[][]) : (string | number)[][]{
-    try{
-        //Check if the preprocessorName exists in preprocessors
-        const exists = preprocessors.some(p => p[0] === preprocessorName);
-        if (!exists) {
-            console.error(`Preprocessor "${preprocessorName}" not found in preprocessors list.`);
-            return [];
-        }    
-    
-        //Find the container for the name passed
-        const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === preprocessorName);
-        
+//Optional services: enhance functionality but are not strictly required for execution.
+export function getOptional(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: (string | number)[][]) : (string | number)[][]{
+    try{   
+        //Find the container for the service name passed
+        const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);
         if(!container){
-            console.error(`Could not find the container for preprocessor ${preprocessorName}`);
+            console.error(`Could not find the container for the service:  ${serviceName}`);
             return [];
         }
         if (container.Labels?.[_OPTIONAL_LABEL_] == undefined) {
-            console.warn(`Warning: The optional dependencies label is missing for preprocessor "${container.Labels["com.docker.compose.service"]}".`);
+            console.warn(`Warning: The optional dependencies label is missing for service:  "${container.Labels["com.docker.compose.service"]}".`);
             return [];
         }
        
-        const optionalPreprocessors = container.Labels[_OPTIONAL_LABEL_];
-        let optionalPreprocessorsArray : string[] = [];
+        const optionalServices = container.Labels[_OPTIONAL_LABEL_];
+        let optionalArr : string[] = [];
         
         //convert from string to array of strings 
-        if(optionalPreprocessors != ""){    //if the preprocessor has dependencies
-            optionalPreprocessorsArray = optionalPreprocessors ? optionalPreprocessors.split(",").filter(Boolean) : [];
+        if(optionalServices != ""){    //if the preprocessor has dependencies
+            optionalArr = optionalServices ? optionalServices.split(",").filter(Boolean) : [];
         }
         
-        //filter through the array of preprocessor names and return an array of their actual values
-        return preprocessors.filter(function (p) { return optionalPreprocessorsArray.includes(p[0] as string); });
+        //filter through the array of preprocessor & handler names and return an array of their actual values
+        return servicesArray.filter(function (p) { return optionalArr.includes(p[0] as string); });
+        
     } catch(error){
-        console.error(`Error while getting optional dependencies for ${preprocessorName}:`, error);
+        console.error(`Error while getting optional dependencies for ${serviceName}:`, error);
         return [];
     }
 
 }
 
 //Returns the required preprocessors/handlers needed for the given preprocessor/handler to run 
-export function getRequired(containers: Docker.ContainerInfo[], preprocessorName: string, preprocessors: (string | number)[][]) : (string | number)[][]{
+export function getRequired(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: (string | number)[][]) : (string | number)[][]{
     try{
-        //Find the container for the name passed
-        const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === preprocessorName);
+        //Find the container for the service name passed
+        const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);
         if(!container){
-            console.error(`Could not find the container for preprocessor ${preprocessorName}`);
+            console.error(`Could not find the container for the service: ${serviceName}`);
             return [];
         }
         if (container.Labels?.[_REQUIRED_LABEL_] == undefined) {
-            console.warn(`Warning: The required dependencies label is missing for preprocessor "${preprocessorName}".`);
+            console.warn(`Warning: The required dependencies label is missing for service: "${serviceName}".`);
             return [];
         }
 
-        const requiredPreprocessors = container.Labels[_REQUIRED_LABEL_];
-        let requiredPreprocessorsArray : string[] = [];
+        const requiredServices = container.Labels[_REQUIRED_LABEL_];
+        let requiredArr : string[] = [];
         
         //convert from string to array of strings 
-        if(requiredPreprocessors != ""){    //if the preprocessor has dependencies
-            requiredPreprocessorsArray = requiredPreprocessors.split(",").filter(Boolean);
+        if(requiredServices != ""){    //if the preprocessor/handler has dependencies
+            requiredArr = requiredServices.split(",").filter(Boolean);
         }
         
-        //filter through the array of preprocessor names and return an array of their actual values
-        const f =  preprocessors.filter(function (p) { return requiredPreprocessorsArray.includes(p[0] as string); });
-        return f;
+        //filter through the array of preprocessor & handler names and return an array of their actual values
+        return servicesArray.filter(function (p) { return requiredArr.includes(p[0] as string); });
     } catch(error){
-        console.error(`Error while getting required dependencies for ${preprocessorName}:`, error);
+        console.error(`Error while getting required dependencies for ${serviceName}:`, error);
         return [];
     }
 } 

--- a/orchestrator/src/graph.ts
+++ b/orchestrator/src/graph.ts
@@ -36,11 +36,7 @@ export class Graph {
         const requiredServices = getRequired(containers, service[0] as string, P);
         let optionalPreprocessors = [] as (string | number)[][];
         //Only get the optional preprocessors if its a preprocessor
-        //Current assumption is that handlers will not have optional dependencies
-        //Specific to preprocessors
-        if(P.some(p => p[0] == service[0])){
-          optionalPreprocessors = getOptional(containers, service[0] as string, P);
-        } 
+        optionalPreprocessors = getOptional(containers, service[0] as string, P);
         
 
         if(optionalPreprocessors && requiredServices && requiredServices.every((r) => Pset.has(r[0] as string))){

--- a/orchestrator/src/graph.ts
+++ b/orchestrator/src/graph.ts
@@ -33,10 +33,10 @@ export class Graph {
       }
       
       for (const service of combinedArray) {
-        const requiredServices = getRequired(containers, service[0] as string, P);
+        const requiredServices = getRequired(containers, service[0] as string, combinedArray);
         let optionalPreprocessors = [] as (string | number)[][];
         //Only get the optional preprocessors if its a preprocessor
-        optionalPreprocessors = getOptional(containers, service[0] as string, P);
+        optionalPreprocessors = getOptional(containers, service[0] as string, combinedArray);
         
 
         if(optionalPreprocessors && requiredServices && requiredServices.every((r) => Pset.has(r[0] as string))){

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -467,11 +467,19 @@ app.post("/render", (req: express.Request, res: express.Response) => {
                     console.debug("Dependency graph passes failed check. Please ensure that the preprocesors don't have cyclic dependencies.");
                     console.debug("Using priority level execution...");
                     data = await runPreprocessorsParallel(data, preprocessors);
+                    const handlerResults: any[][] = await Promise.all(
+                        handlers.map(handler => executeHandler(handler, data))
+                    );                
+                    response = finalizeResponse(handlerResults, requestBody, res);
                 }
 
             } else {
                 console.debug("Running preprocessors in series...");
                 data = await runPreprocessors(data, preprocessors);
+                const handlerResults: any[][] = await Promise.all(
+                    handlers.map(handler => executeHandler(handler, data))
+                );                
+                response = finalizeResponse(handlerResults, requestBody, res);
             }
             
             if (process.env.STORE_IMAGE_DATA === "on" || process.env.STORE_IMAGE_DATA === "ON") {


### PR DESCRIPTION
Resolves #998 
Running handlers as soon as they are ready for execution by checking their dependencies.
Changes made:
- Modularized Handler execution so handlers are run alongside preprocessors versus all at once at the end as done beforehand.
- All logic pertaining to rendering storing and filtering is also modularized in different functions.
- Handlers now have optional and required dependencies which required docker compose changes.
- Modified docker-compose by adding optional dependencies for `photo-audio-handler`
Changes in logs: 
- Now includes timestamp and execution time for handlers as well.
-  Displays total execution time for the render endpoint. 

Tested by checking renderings on multiple images & comparing execution time with different images and commits.


---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
