### PR TITLE
Handle map source data in monarch-link-app

### DIFF
--- a/services/monarch-link-app/app.py
+++ b/services/monarch-link-app/app.py
@@ -135,6 +135,10 @@ def update(id):
                     # include source graphic if present
                     if "graphicBlob" in req_data:
                         svgData[id]["graphicBlob"] = req_data["graphicBlob"]
+                    elif "coordinates" in req_data:
+                        svgData[id]["coordinates"] = req_data["coordinates"]
+                    elif "placeID" in req_data:
+                        svgData[id]["placeID"] = req_data["placeID"]
                     write_data(svgData)
                     logging.debug('Updated graphic')
                     return "Graphic in channel "+id+" has been updated!"
@@ -152,6 +156,10 @@ def update(id):
                 # include source graphic if present
                 if "graphicBlob" in req_data:
                     svgData[id]["graphicBlob"] = req_data["graphicBlob"]
+                elif "coordinates" in req_data:
+                    svgData[id]["coordinates"] = req_data["coordinates"]
+                elif "placeID" in req_data:
+                    svgData[id]["placeID"] = req_data["placeID"]
                 write_data(svgData)
                 logging.debug('TEMP: Created new channel using update!')
                 return ("New channel created with code "+id +
@@ -180,6 +188,10 @@ def display(id):
                                           "layer": svgData[id]["layer"]}}]}
                 if "graphicBlob" in svgData[id]:
                     response_val["graphicBlob"] = svgData[id]["graphicBlob"]
+                elif "coordinates" in svgData[id]:
+                    response_val["coordinates"] = svgData[id]["coordinates"]
+                elif "placeID" in svgData[id]:
+                    response_val["placeID"] = svgData[id]["placeID"]
                 response.set_data(json.dumps(response_val))
                 response.add_etag(hashlib.md5(
                     (svgData[id]["data"]+svgData[id]["layer"]).encode()))


### PR DESCRIPTION
With the changes made #981, the map coordinates or placeID data are being sent over to the monarch-link-app. Changes have been made to the monarch-link-app for storing and then providing these data on GET requests to the display/<share_code>endpoint. 

TESTING: 
The logic used for "placeID" and "coordinates" is identical to that used for the "graphicBlob" property with the assumption that only one of the three will be present. No additional testing was conducted for this purpose.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
