### PR TITLE
Update tat Dockerfile to use SERVER_URL at build

### DIFF
--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -24,7 +24,14 @@ ENV npm_config_ignore_scripts=true
 WORKDIR /app/packages/svgcanvas
 RUN npx rollup -c
 WORKDIR /app
-RUN npx rollup -c
+# Set server url based on registry tag
+ARG REGISTRY_TAG
+RUN if [ ${REGISTRY_TAG} = "unstable" ]; then \
+    npx rollup -c --environment SERVER_URL:"https://unicorn.cim.mcgill.ca/image/monarch/"; \
+else \
+    npx rollup -c --environment SERVER_URL:"https://image.a11y.mcgill.ca/image/monarch/"; \
+fi
+
 
 # Stage 2: Serve the application
 FROM nginx:alpine


### PR DESCRIPTION
The tat needs to point to the correct monarch-link-app endpoint in both development and production. To enable this, changes have been made to the Dockerfile to set SERVER_URL value at build time based on the REGISTRY_TAG. 

TESTING:
This was tested in dev environment. Building using this Dockerfile with REGISTRY_TAG=unstable results in requests being sent correctly to https://unicorn.cim.mcgill.ca/image/monarch/

Closes #1003. 
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
