### PR TITLE
Extend orchestrator timeout to 90 s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - PARALLEL_PREPROCESSORS=ON
       - STORE_IMAGE_DATA=ON
       - MEMCACHE_SERVERS=memcached:11211
+      - PREPROCESSOR_TIMEOUT=90000
     env_file:
       - ./config/express-common.env
     group_add:


### PR DESCRIPTION
Extend the orchestrator timeout to 90 seconds to accommodate the `multistage-diagram-segmentation` preprocessor that takes approx. 45-60 seconds to process complex diagrams.
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
