### PR TITLE
Fix hex-coded characters in Ollama responses

### DIFF
--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -21,6 +21,7 @@ import time
 import jsonschema
 import logging
 import os
+import html
 from datetime import datetime
 from config.logging_utils import configure_logging
 
@@ -122,7 +123,7 @@ def categorise():
     if response.status_code == 200:
         response_text = response.text
         data = json.loads(response_text)
-        graphic_caption = data['response']
+        graphic_caption = html.unescape(data['response'])
     else:
         logging.error("Error: {response.text}")
         return jsonify("Invalid response from ollama"), 500
@@ -153,7 +154,7 @@ def categorise():
         return jsonify("Invalid Preprocessor JSON format"), 500
 
     # all done; return to orchestrator
-    return response
+    return jsonify(response)
 
 
 @app.route("/health", methods=["GET"])

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -21,6 +21,7 @@ import time
 import jsonschema
 import logging
 import os
+import html
 from datetime import datetime
 from config.logging_utils import configure_logging
 
@@ -269,7 +270,7 @@ def followup():
             # Format assistant response for history
             model_resp = {
                 "role": "assistant",
-                "content": response_text
+                "content": html.unescape(response_text)
             }
 
             # Update conversation history
@@ -326,7 +327,7 @@ def followup():
 
     logging.debug("full response length: " + str(len(response)))
     logging.pii(response)
-    return response
+    return jsonify(response)
 
 
 # Two following endpoints don't have immediate use


### PR DESCRIPTION
Characters like `&#x27` were found in responses from Ollama.
This PR fixes the issue:
- `html.unescape()` converts characters from the HTML code
- `jsonify` ensures special characters are escaped while constructing the response object

Tested by forcing Ollama to generate text with quotation marks and apostrophes and checking the text representation in the extension and logs.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
