### PR TITLE
Fix quotation marks in prod docker compose

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -56,7 +56,7 @@ services:
   tat:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.tat.rule=Host(image.a11y.mcgill.ca) && PathPrefix(/tat)"
+      - "traefik.http.routers.tat.rule=Host(`image.a11y.mcgill.ca`) && PathPrefix(`/tat`)"
       - "traefik.http.routers.tat.tls.certresolver=myresolver"
       - "traefik.http.middlewares.tat-stripprefix.stripprefix.prefixes=/tat"
       - "traefik.http.routers.tat.middlewares=tat-stripprefix@docker"


### PR DESCRIPTION
Add missing quote marks in prod-docker-compose tat entry.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
