### PR TITLE
Correct path of monarch-link-app in production

### DIFF
--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -29,7 +29,7 @@ ARG REGISTRY_TAG
 RUN if [ ${REGISTRY_TAG} = "unstable" ]; then \
     npx rollup -c --environment SERVER_URL:"https://unicorn.cim.mcgill.ca/image/monarch/"; \
 else \
-    npx rollup -c --environment SERVER_URL:"https://image.a11y.mcgill.ca/image/monarch/"; \
+    npx rollup -c --environment SERVER_URL:"https://image.a11y.mcgill.ca/monarch/"; \
 fi
 
 


### PR DESCRIPTION
Correct path in tat dockerfile to use `https://image.a11y.mcgill.ca/monarch/` and not `https://image.a11y.mcgill.ca/image/monarch/`

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
