### PR TITLE
traefik tat and monarch knockouts

### DIFF
--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -11,7 +11,8 @@ services:
       - "traefik.http.middlewares.peg-redirect.redirectregex.permanent=true"
       - "traefik.http.routers.atp-pegasus.middlewares=peg-redirect@docker"
 
-      - "traefik.http.routers.image.rule=Host(`image.a11y.mcgill.ca`) || Host(`image.ally.mcgill.ca`) || Host(`image.accessibility.mcgill.ca`)"
+      - "traefik.http.routers.image.rule=(Host(`image.a11y.mcgill.ca`) || Host(`image.ally.mcgill.ca`) || Host(`image.accessibility.mcgill.ca`)) \
+          && !(PathPrefix(`/tat`) || PathPrefix(`/monarch`))"
       - "traefik.http.middlewares.ally-redirect.redirectregex.regex=^(https?)://image.(ally|accessibility).mcgill.ca(/?.*)"
       - "traefik.http.middlewares.ally-redirect.redirectregex.replacement=$${1}://image.a11y.mcgill.ca$${3}"
       - "traefik.http.middlewares.ally-redirect.redirectregex.permanent=true"


### PR DESCRIPTION
For production, endpoints /tat and /monarch were being picked up by the Host clauses of the website container. This PR specifically tells the webserver docker-compose entry to not pay attention to these two endpoints, so that they are handled by the tat and monarch containers instead.

Tested directly on pegasus with @VenissaCarolQuadros testing the endpoints, and verifying that "normal" IMAGE graphic queries still function, and the website still appears at the base url `image.a11y.mcgill.ca`

@JRegimbal Ping in case there is a cleaner way of handling this off the top of your head. There is a broader discussion of server name conventions and how they are set that needs to be had, but after demos.


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR. [NA]
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
