### PR TITLE
graphic caption change "false" string to False boolean in ollama request

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -86,7 +86,7 @@ def categorise():
         logging.pii("OLLAMA_API_KEY looks properly formatted: " +
                     api_key[:3] + "[redacted]")
     else:
-        logging.warn("OLLAMA_API_KEY usually starts with sk-, "
+        logging.warning("OLLAMA_API_KEY usually starts with sk-, "
                      "but this one starts with: " + api_key[:3])
 
     prompt = "Answer only in JSON with the format " \
@@ -103,7 +103,7 @@ def categorise():
         "model": ollama_model,
         "prompt": prompt,
         "images": [graphic_b64],
-        "stream": "false",
+        "stream": False,
         "format": "json",
         "temperature": 0.0,
         "keep_alive": -1  # keep model loaded in memory indefinitely
@@ -197,4 +197,3 @@ def health():
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=5000, debug=True)
-    categorise()

--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -87,7 +87,7 @@ def categorise():
                     api_key[:3] + "[redacted]")
     else:
         logging.warning("OLLAMA_API_KEY usually starts with sk-, "
-                     "but this one starts with: " + api_key[:3])
+                        "but this one starts with: " + api_key[:3])
 
     prompt = "Answer only in JSON with the format " \
              '{"category": "YOUR_ANSWER"}. ' \


### PR DESCRIPTION
Shahd was getting failures of graphic-caption on EC2, with the following error in logs:

```
content-categoriser-1      | 2025-05-09T18:52:43.160038359Z ERROR:root:Error: {“error”:“json: cannot unmarshal string into Go struct field GenerateRequest.stream of type bool”} (edited) 
```

Mike and Shahd both caught that in my request generation code, I was using "false" as a string instead of False as a boolean. Hypothesis is that this is caught by more recent versions of ollama than the one on pegasus, so am making this fix for her to test.

Tested on unicorn with override, and photo request succeeds. Note that this change matches the text-followup request generation, which has False as a boolean and has been through considerable testing, so this seems like a very safe change.

At same time, removing unnecessary function call at bottom of file.


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
