### PR TITLE
Change the Ollama API key warning message

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -86,8 +86,11 @@ def categorise():
         logging.pii("OLLAMA_API_KEY looks properly formatted: " +
                     api_key[:3] + "[redacted]")
     else:
-        logging.warning("OLLAMA_API_KEY usually starts with sk-, "
-                        "but this one starts with: " + api_key[:3])
+        logging.warning(f'''OLLAMA_API_KEY usually starts with sk-,
+                        but this one starts with: {api_key[:3]}.
+                        You either entered an incorrect API key,
+                        or used a JWT token instead.'''
+                        )
 
     prompt = "Answer only in JSON with the format " \
              '{"category": "YOUR_ANSWER"}. ' \

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -96,8 +96,11 @@ def categorise():
         logging.debug("OLLAMA_API_KEY looks properly formatted: " +
                       api_key[:3] + "[redacted]")
     else:
-        logging.warn("OLLAMA_API_KEY usually starts with sk-, "
-                     "but this one starts with: " + api_key[:3])
+        logging.warning(f'''OLLAMA_API_KEY usually starts with sk-,
+                        but this one starts with: {api_key[:3]}.
+                        You either entered an incorrect API key,
+                        or used a JWT token instead.'''
+                        )
 
     request_data = {
         "model": ollama_model,


### PR DESCRIPTION
Resolves #1058 
Changed the warning message to provide developers with more information on the Ollama API key use.

Tested on Unicorn with an invalid API key and with a JWT token instead of the API key.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
