### PR TITLE
Check for graphic before checking URL

### DIFF
--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -662,6 +662,10 @@ def process_diagram():
 
     # 0. Check the URL of the request to avoid processing PII in production
     # until the Google API is approved for use
+    # Check if there is graphic content to process
+    if "graphic" not in content:
+        logging.info("No graphic content. Skipping...")
+        return jsonify({"error": "No graphic content"}), 204
     if (content["URL"] !=
             "https://image.a11y.mcgill.ca/pages/multistage_diagrams.html"):
         logging.info(
@@ -680,11 +684,6 @@ def process_diagram():
         logging.error("Validation failed for incoming request")
         logging.pii(f"Validation error: {e.message} | Data: {content}")
         return jsonify({"error": "Invalid Preprocessor JSON format"}), 400
-
-    # Check if there is graphic content to process
-    if "graphic" not in content:
-        logging.info("No graphic content. Skipping...")
-        return jsonify({"error": "No graphic content"}), 204
 
     request_uuid = content["request_uuid"]
     timestamp = time.time()


### PR DESCRIPTION
Resolves #1037 
I moved the check for the graphic content before the URL check.
Now, if the preprocessor is presented with the non-graphic (e.g. map) content, it will automatically skip any further actions.

Tested on Unicorn (using the map on the IMAGE website).

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
