### PR TITLE
Run segmentation in one call

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     environment:
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
       - SAM_MODEL_PATH=/usr/src/app/models/sam2.1_l.pt
-      - GEMINI_MODEL=gemini-2.5-pro-preview-03-25
+      - GEMINI_MODEL=gemini-2.5-pro-preview-05-06
       - BASE_SCHEMA=/usr/src/app/base_schema.json
     env_file:
       ./config/gemini.env   

--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -547,9 +547,6 @@ def segment_stages(
             normalized_contours = extract_normalized_contours(
                 result, width, height
                 )
-            logging.pii(
-                f"Found {len(normalized_contours)} contour(s) for '{label}'"
-                )
             aggregated_contour_data[label].extend(normalized_contours)
 
     except Exception as e:


### PR DESCRIPTION
Resolves #1039 

Contour extraction (the last step of stage extraction) is now done in one call to the segmentation model (as opposed to one call per diagram stage previously).  
The `Ultralytics` library implements batching on the GPU level, so it's likely to be more efficient than trying to parallelize it on the Python level.

This reduces the preprocessor run time to 15..25 seconds, with most of it being processing of the first two steps by the large Gemini model.

Extra: updated the model version to the latest (`gemini-2.5-pro-preview-05-06`) after checking that it doesn't break the component.

Tested on Unicorn using demo diagrams.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
