### PR TITLE
Let pseudo-preprocessors modify requests

### DIFF
--- a/orchestrator/src/docker.ts
+++ b/orchestrator/src/docker.ts
@@ -14,6 +14,7 @@
  * and our Additional Terms along with this program.
  * If not, see <https://github.com/Shared-Reality-Lab/IMAGE-server/blob/main/LICENSE>.
  */
+import { PreprocessorInfo } from "./server";
 import Docker from "dockerode";
 
 export const docker = new Docker();
@@ -27,6 +28,7 @@ const _CACHE_TIMEOUT_LABEL = "ca.mcgill.a11y.image.cacheTimeout";
 const _ORCHESTRATOR_ID_ = process.env.HOSTNAME as string;
 export const DEFAULT_ROUTE_NAME = "default";
 const _ROUTE_LABEL_ = "ca.mcgill.a11y.image.route";
+const _MODIFY_REQUEST_LABEL_ = "ca.mcgill.a11y.image.modifyRequest";
 
 function getOrchestratorNetworks(containers: Docker.ContainerInfo[]): string[] {
     const container = containers.filter(c => c.Id.startsWith(_ORCHESTRATOR_ID_)).shift();
@@ -86,6 +88,7 @@ export function getPreprocessorServices(containers: Docker.ContainerInfo[], rout
         const portLabel = container.Labels[_PORT_LABEL_];
         const priorityLabel = Number(container.Labels[_PREPROCESSOR_LABEL_]);
         const cacheTimeout = Number(container.Labels[_CACHE_TIMEOUT_LABEL] || 0);
+        const modifyRequest = Boolean(container.Labels[_MODIFY_REQUEST_LABEL_] || false);
 
         let port;
         if (portLabel !== undefined) {
@@ -96,7 +99,7 @@ export function getPreprocessorServices(containers: Docker.ContainerInfo[], rout
         } else {
             port = 80;
         }
-        return [container.Labels["com.docker.compose.service"], port, priorityLabel, cacheTimeout];
+        return [container.Labels["com.docker.compose.service"], port, priorityLabel, cacheTimeout, modifyRequest];
     });
 }
 
@@ -125,7 +128,7 @@ export function getHandlerServices(containers: Docker.ContainerInfo[], route: st
 
 //Returns the optional preprocessors/handlers needed for the given preprocessor/handler to run 
 //Optional services: enhance functionality but are not strictly required for execution.
-export function getOptional(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: (string | number)[][]) : (string | number)[][]{
+export function getOptional(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: PreprocessorInfo[]) : PreprocessorInfo[]{
     try{   
         //Find the container for the service name passed
         const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);
@@ -157,7 +160,7 @@ export function getOptional(containers: Docker.ContainerInfo[], serviceName: str
 }
 
 //Returns the required preprocessors/handlers needed for the given preprocessor/handler to run 
-export function getRequired(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: (string | number)[][]) : (string | number)[][]{
+export function getRequired(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: PreprocessorInfo[]) : PreprocessorInfo[]{
     try{
         //Find the container for the service name passed
         const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);

--- a/orchestrator/src/docker.ts
+++ b/orchestrator/src/docker.ts
@@ -14,7 +14,7 @@
  * and our Additional Terms along with this program.
  * If not, see <https://github.com/Shared-Reality-Lab/IMAGE-server/blob/main/LICENSE>.
  */
-import { PreprocessorInfo } from "./server";
+import { ServiceInfo } from "./server";
 import Docker from "dockerode";
 
 export const docker = new Docker();
@@ -128,7 +128,7 @@ export function getHandlerServices(containers: Docker.ContainerInfo[], route: st
 
 //Returns the optional preprocessors/handlers needed for the given preprocessor/handler to run 
 //Optional services: enhance functionality but are not strictly required for execution.
-export function getOptional(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: PreprocessorInfo[]) : PreprocessorInfo[]{
+export function getOptional(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: ServiceInfo[]) : ServiceInfo[]{
     try{   
         //Find the container for the service name passed
         const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);
@@ -160,7 +160,7 @@ export function getOptional(containers: Docker.ContainerInfo[], serviceName: str
 }
 
 //Returns the required preprocessors/handlers needed for the given preprocessor/handler to run 
-export function getRequired(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: PreprocessorInfo[]) : PreprocessorInfo[]{
+export function getRequired(containers: Docker.ContainerInfo[], serviceName: string, servicesArray: ServiceInfo[]) : ServiceInfo[]{
     try{
         //Find the container for the service name passed
         const container = containers.find(c => c.Labels?.["com.docker.compose.service"] === serviceName);

--- a/orchestrator/src/graph.ts
+++ b/orchestrator/src/graph.ts
@@ -1,3 +1,4 @@
+import {PreprocessorInfo} from "./server";
 import { getOptional, getRequired } from "./docker";
 import Docker from "dockerode";
 
@@ -9,7 +10,7 @@ export class Graph {
       this.nodes = new Map();
     }
   
-    addNode(service : (string | number)[], isPreprocessor: boolean): GraphNode {
+    addNode(service : PreprocessorInfo, isPreprocessor: boolean): GraphNode {
       const name = service[0] as string; 
       if (!this.nodes.has(name)) {
         const newNode = new GraphNode(service);
@@ -23,9 +24,9 @@ export class Graph {
       return this.nodes.get(name)!;
     }
 
-    async constructGraph(P: (string | number)[][], H: (string | number)[][], containers: Docker.ContainerInfo[]) : Promise<Set<GraphNode>>  {
+    async constructGraph(P: PreprocessorInfo[], H: (string | number)[][], containers: Docker.ContainerInfo[]) : Promise<Set<GraphNode>>  {
       const R = new Set<GraphNode>();
-      const combinedArray = P.concat(H);
+      const combinedArray = P.concat(H as PreprocessorInfo[]);
 
       const Pset = new Set<string>();
       for(const preprocessor of P){
@@ -34,7 +35,7 @@ export class Graph {
       
       for (const service of combinedArray) {
         const requiredServices = getRequired(containers, service[0] as string, combinedArray);
-        let optionalPreprocessors = [] as (string | number)[][];
+        let optionalPreprocessors = [] as PreprocessorInfo[] 
         //Only get the optional preprocessors if its a preprocessor
         optionalPreprocessors = getOptional(containers, service[0] as string, combinedArray);
         
@@ -103,12 +104,12 @@ export class Graph {
 }
   
 export class GraphNode {
-    value: (string | number)[];    //preprocessor that this node represents
+    value: PreprocessorInfo;    //preprocessor that this node represents
     parents: Set<GraphNode>;
     children: Set<GraphNode>;
     type: string;
 
-    constructor(preprocessors: (string | number)[]) {
+    constructor(preprocessors: PreprocessorInfo) {
       this.value = preprocessors;
       this.parents = new Set();
       this.children = new Set();

--- a/orchestrator/src/graph.ts
+++ b/orchestrator/src/graph.ts
@@ -1,4 +1,4 @@
-import {PreprocessorInfo} from "./server";
+import {ServiceInfo} from "./server";
 import { getOptional, getRequired } from "./docker";
 import Docker from "dockerode";
 
@@ -10,7 +10,7 @@ export class Graph {
       this.nodes = new Map();
     }
   
-    addNode(service : PreprocessorInfo, isPreprocessor: boolean): GraphNode {
+    addNode(service : ServiceInfo, isPreprocessor: boolean): GraphNode {
       const name = service[0] as string; 
       if (!this.nodes.has(name)) {
         const newNode = new GraphNode(service);
@@ -24,9 +24,9 @@ export class Graph {
       return this.nodes.get(name)!;
     }
 
-    async constructGraph(P: PreprocessorInfo[], H: (string | number)[][], containers: Docker.ContainerInfo[]) : Promise<Set<GraphNode>>  {
+    async constructGraph(P: ServiceInfo[], H: (string | number)[][], containers: Docker.ContainerInfo[]) : Promise<Set<GraphNode>>  {
       const R = new Set<GraphNode>();
-      const combinedArray = P.concat(H as PreprocessorInfo[]);
+      const combinedArray = P.concat(H as ServiceInfo[]);
 
       const Pset = new Set<string>();
       for(const preprocessor of P){
@@ -35,7 +35,7 @@ export class Graph {
       
       for (const service of combinedArray) {
         const requiredServices = getRequired(containers, service[0] as string, combinedArray);
-        let optionalPreprocessors = [] as PreprocessorInfo[] 
+        let optionalPreprocessors = [] as ServiceInfo[] 
         //Only get the optional preprocessors if its a preprocessor
         optionalPreprocessors = getOptional(containers, service[0] as string, combinedArray);
         
@@ -104,12 +104,12 @@ export class Graph {
 }
   
 export class GraphNode {
-    value: PreprocessorInfo;    //preprocessor that this node represents
+    value: ServiceInfo;    //preprocessor that this node represents
     parents: Set<GraphNode>;
     children: Set<GraphNode>;
     type: string;
 
-    constructor(preprocessors: PreprocessorInfo) {
+    constructor(preprocessors: ServiceInfo) {
       this.value = preprocessors;
       this.parents = new Set();
       this.children = new Set();

--- a/orchestrator/src/server.ts
+++ b/orchestrator/src/server.ts
@@ -42,6 +42,8 @@ interface HandlerResponse {
         type_id: string;
     }>;
 }
+
+export type PreprocessorInfo = (string | number | boolean)[]
 import { Graph, GraphNode, printGraph } from "./graph";
 
 const app = express();
@@ -59,6 +61,14 @@ const ajv = new Ajv2020({
 const PREPROCESSOR_TIME_MS = (!isNaN(parseInt(process.env.PREPROCESSOR_TIMEOUT || ""))) ? parseInt(process.env.PREPROCESSOR_TIMEOUT || "") : 15000;
 
 const BASE_LOG_PATH = path.join("/var", "log", "IMAGE");
+
+const MODIFY_REQUEST_INDEX = 4;  // The index returned by getPreprocessorServices corresponding to modifyRequest
+const NAME_MODIFY_REQUEST = "ca.mcgill.a11y.image.request";
+const RESTRICTED_FIELDS = [
+    "request_uuid",
+    "timestamp",
+    "preprocessors",
+];
 
 app.use(express.json({limit: process.env.MAX_BODY}));
 
@@ -110,7 +120,7 @@ async function checkCache(preprocessorName: string, hashedKey: string, cacheTime
     return null; // cache miss
 }
 
-async function fetchPreprocessorResponse(preprocessor: (string | number)[], data: Record<string, unknown>): Promise<Response> {
+async function fetchPreprocessorResponse(preprocessor: PreprocessorInfo, data: Record<string, unknown>): Promise<Response> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), PREPROCESSOR_TIME_MS);
     try {
@@ -128,19 +138,36 @@ async function fetchPreprocessorResponse(preprocessor: (string | number)[], data
     }
 }
 
-async function processResponse(response: Response, preprocessor: (string | number)[], data: Record<string, unknown>, hashedKey: string, cacheTimeOut: number): Promise<void> {
+async function processResponse(response: Response, preprocessor: PreprocessorInfo, data: Record<string, unknown>, hashedKey: string, cacheTimeOut: number): Promise<void> {
     if (response.status === 200) {
         const jsonResponse = await response.json() as PreprocessorResponse;
         if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", jsonResponse)) {
-            const preprocessorName = jsonResponse["name"];
-            (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = jsonResponse["data"]; 
-            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP 
-            SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = preprocessorName;
-            // store data in cache
-            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
-            if (cacheTimeOut > 0) {
-                console.debug(`Saving response for ${preprocessorName} in cache with key ${hashedKey}`);
-                await serverCache.setResponseInCache(hashedKey, JSON.stringify(jsonResponse["data"]), cacheTimeOut);
+            if (preprocessor[MODIFY_REQUEST_INDEX] == false) {
+                const preprocessorName = jsonResponse["name"];
+                (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = jsonResponse["data"]; 
+                // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP 
+                SERVICE_PREPROCESSOR_MAP[preprocessor[0] as string] = preprocessorName;
+                // store data in cache
+                // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
+                if (cacheTimeOut > 0) {
+                    console.debug(`Saving response for ${preprocessorName} in cache with key ${hashedKey}`);
+                    await serverCache.setResponseInCache(hashedKey, JSON.stringify(jsonResponse["data"]), cacheTimeOut);
+                }
+            } else {
+                // Verify that name in response matches expectation.
+                if (jsonResponse["name"] != NAME_MODIFY_REQUEST) {
+                    console.debug(`Pseudo-preprocessor ${preprocessor[0]} attempted to modify the request, but returned unexpected name ${jsonResponse["name"]}. Ignoring response.`);
+                } else {
+                    // Make transmitted modifications, within reason.
+                    for (const [field, value] of Object.entries(jsonResponse["data"])) {
+                        if (RESTRICTED_FIELDS.includes(field)) {
+                            console.debug(`Pseudo-preprocessor ${preprocessor[0]} attempted to modify restricted request field '${field}'. Ignoring modification.`);
+                        } else {
+                            data[field] = value;
+                        }
+                    }
+                    // TODO caching
+                }
             }
         } else {
             console.error(`Preprocessor "${preprocessor[0]}" response validation failed!`);
@@ -153,7 +180,7 @@ async function processResponse(response: Response, preprocessor: (string | numbe
     }
 }
 
-async function executeHandler(handler: (string | number)[], data: Record<string, unknown>): Promise<any[]> {
+async function executeHandler(handler: PreprocessorInfo, data: Record<string, unknown>): Promise<any[]> {
     return measureExecutionTime(`Handler "${handler[0]}"`, async () => {
         try {
             const resp = await fetch(`http://${handler[0]}:${handler[1]}/handler`, {
@@ -193,16 +220,17 @@ async function executeHandler(handler: (string | number)[], data: Record<string,
     });
 }
 
-async function executePreprocessor(preprocessor: (string | number)[], data: Record<string, unknown>): Promise<void> {
-    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
+async function executePreprocessor(preprocessor: PreprocessorInfo, data: Record<string, unknown>): Promise<void> {
+    const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0] as string] || '';
     const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
     const cacheTimeOut = preprocessor[3] as number;
+    const isModifyRequest = preprocessor[MODIFY_REQUEST_INDEX] as boolean;
 
     // profile preprocessor lifecycle performance
     await measureExecutionTime(`Preprocessor "${preprocessor[0]}"`, async () => {
         // check if a cached response exists for the current preprocessor
         const cacheResponse = await checkCache(preprocessorName, hashedKey, cacheTimeOut);
-        if (cacheResponse) {  // if the response is found in cache, update `data` directly without making any calls
+        if (cacheResponse && !isModifyRequest) {  // if the response is found in cache, update `data` directly without making any calls
             (data["preprocessors"] as Record<string, unknown>)[preprocessorName] = cacheResponse;
             return; // cache hit, no further processing is needed
         }
@@ -215,7 +243,7 @@ async function executePreprocessor(preprocessor: (string | number)[], data: Reco
     });
 }
 
-async function runServicesParallel(data: Record<string, unknown>, preprocessors: (string | number)[][], G: Graph, R: Set<GraphNode>): Promise<{ data: Record<string, unknown>, handlerResults: any[][] }> {
+async function runServicesParallel(data: Record<string, unknown>, preprocessors: PreprocessorInfo[], G: Graph, R: Set<GraphNode>): Promise<{ data: Record<string, unknown>, handlerResults: any[][] }> {
     if (data["preprocessors"] === undefined) {
         data["preprocessors"] = {};
     }
@@ -251,12 +279,12 @@ async function executeGraphNode(service: GraphNode, data: Record<string, unknown
     await Promise.all(newRun);
 }
 
-async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
+async function runPreprocessorsParallel(data: Record<string, unknown>, preprocessors: PreprocessorInfo[]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {
         data["preprocessors"] = {};
     }
     let currentPriorityGroup: number | undefined = undefined;
-    const queue: (string | number)[][] = []; //Microservice queue for preprocessors and handlers
+    const queue: PreprocessorInfo[] = []; //Microservice queue for preprocessors and handlers
 
 
     //function that dequeues everything in the queue at once, executes them and waits for them to finish processing
@@ -293,7 +321,7 @@ async function runPreprocessorsParallel(data: Record<string, unknown>, preproces
     return data;
 }
 
-async function runPreprocessors(data: Record<string, unknown>, preprocessors: (string | number)[][]): Promise<Record<string, unknown>> {
+async function runPreprocessors(data: Record<string, unknown>, preprocessors: PreprocessorInfo[]): Promise<Record<string, unknown>> {
     if (data["preprocessors"] === undefined) {
         data["preprocessors"] = {};
     }
@@ -306,7 +334,7 @@ async function runPreprocessors(data: Record<string, unknown>, preprocessors: (s
         let resp;
         // get value from cache for each preprocessor if it exists
         const cacheTimeOut = preprocessor[3] as number;
-        const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0]] || '';
+        const preprocessorName = SERVICE_PREPROCESSOR_MAP[preprocessor[0] as string] || '';
         const hashedKey = serverCache.constructCacheKey(data, preprocessorName);
         const cacheValue = await serverCache.getResponseFromCache(hashedKey);
         if (cacheTimeOut && cacheValue && preprocessorName){
@@ -342,15 +370,30 @@ async function runPreprocessors(data: Record<string, unknown>, preprocessors: (s
                 try {
                     const json = await resp.json() as PreprocessorResponse;
                     if (ajv.validate("https://image.a11y.mcgill.ca/preprocessor-response.schema.json", json)) {
-                        (data["preprocessors"] as Record<string, unknown>)[json["name"]] = json["data"];
-                        // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP
-                        SERVICE_PREPROCESSOR_MAP[preprocessor[0]] = json["name"];
-                        // store the value in cache
-                        // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
-                        if(cacheTimeOut > 0){
-                            const hashedKey =  serverCache.constructCacheKey(data, json["name"]);
-                            console.debug(`Saving Response for ${json["name"]} in cache with key ${hashedKey}`);
-                            await serverCache.setResponseInCache(hashedKey, JSON.stringify(json["data"]), cacheTimeOut)
+                        if (preprocessor[MODIFY_REQUEST_INDEX] == false) {
+                            (data["preprocessors"] as Record<string, unknown>)[json["name"]] = json["data"];
+                            // store preprocessor name returned in SERVICE_PREPROCESSOR_MAP
+                            SERVICE_PREPROCESSOR_MAP[preprocessor[0] as string] = json["name"];
+                            // store the value in cache
+                            // disable the cache if "ca.mcgill.a11y.image.cacheTimeout" is 0
+                            if(cacheTimeOut > 0){
+                                const hashedKey =  serverCache.constructCacheKey(data, json["name"]);
+                                console.debug(`Saving Response for ${json["name"]} in cache with key ${hashedKey}`);
+                                await serverCache.setResponseInCache(hashedKey, JSON.stringify(json["data"]), cacheTimeOut)
+                            }
+                        } else {
+                            if (json["name"] != NAME_MODIFY_REQUEST) {
+                                console.debug(`Pseudo-preprocessor ${preprocessorName} attempted to modify the request, but returned unexpected name ${json["name"]}. Ignoring response.`);
+                            } else {
+                                for (const [field, value] of Object.entries(json["data"])) {
+                                    if (RESTRICTED_FIELDS.includes(field)) {
+                                        console.debug(`Pseudo-preprocessor ${preprocessorName} attempted to modify restricted request field '${field}'. Ignoring modification.`);
+                                    } else {
+                                        data[field] = value;
+                                    }
+                                }
+                                // TODO caching
+                            }
                         }
                     } else {
                         console.error("Preprocessor response failed validation!");
@@ -445,18 +488,40 @@ app.post("/render", (req: express.Request, res: express.Response) => {
             let response: Record<string, unknown> | null = null;
             //Get the list of filtered containers that are connected to one of the Orchestrator networks
             const connectedContainers = getFilteredContainers(containers);
-            const preprocessors = getPreprocessorServices(connectedContainers, route);
+            const allPreprocessors = getPreprocessorServices(connectedContainers, route);
+            const pseudopreprocessors = allPreprocessors.filter(p => p[MODIFY_REQUEST_INDEX] == true);
+            const preprocessors = allPreprocessors.filter(p => p[MODIFY_REQUEST_INDEX] == false);
             const handlers = getHandlerServices(connectedContainers, route);
+
+            // Construct pseudo-preprocessor graph
+            const pseudoGraph = new Graph();
+            const pseudoReady = await pseudoGraph.constructGraph(
+                pseudopreprocessors,
+                [],
+                connectedContainers
+            );
 
             const graph = new Graph();
             //Construct the graph using the handlers and preprocessors 
-            const readyToRun =  await graph.constructGraph(preprocessors, handlers, connectedContainers);
+            const readyToRun =  await graph.constructGraph(
+                preprocessors,
+                handlers,
+                connectedContainers
+            );
             console.debug("Preprocessor graph produced successfully.");
-            
-
 
             // Preprocessors
             if (process.env.PARALLEL_PREPROCESSORS === "ON" || process.env.PARALLEL_PREPROCESSORS === "on") {
+                // Deal with pseudo-preprocessors first, if any
+                if (pseudoGraph.isAcyclic()) {
+                    console.debug("Running pseudo-preprocessors in parallel...");
+                    const { data: modifiedData, handlerResults: tmpHResults} = await runServicesParallel(data, pseudopreprocessors, pseudoGraph, pseudoReady);
+                    data = modifiedData;
+                } else {
+                    console.debug("Dependency graph has cycles, please check for cyclic dependencies in pseudopreprocessors.");
+                    console.debug("Defaulting to serial execution.");
+                    data = await runPreprocessors(data, pseudopreprocessors);
+                }
                 console.debug("Running preprocessors in parallel...");
                 if(graph.isAcyclic()){
                     console.debug("Dependency graph passes cycle check.");
@@ -474,6 +539,8 @@ app.post("/render", (req: express.Request, res: express.Response) => {
                 }
 
             } else {
+                console.debug("Running pseudo-preprocessors in series...");
+                data = await runPreprocessors(data, pseudopreprocessors);
                 console.debug("Running preprocessors in series...");
                 data = await runPreprocessors(data, preprocessors);
                 const handlerResults: any[][] = await Promise.all(


### PR DESCRIPTION
No, I'm not married to the name "pseudo-preprocessors".

Resolve #1008, resolve #1028. Allows for preprocessors to modify the request if:
* They have the label `ca.mcgill.a11y.image.modifyRequest: true`
* They use the name `ca.mcgill.a11y.image.request`.

Certain fields in the request, such as `request_uuid`, cannot be modified.

Tested using the graph-based scheduler and the priority based one. It seems to be working with a toy pseudo-preprocessor.

Note that caching currently does not and **cannot** work with pseudo-preprocessors as implemented. Data is retrieved from the cache using the name in the response, which for these will always be `ca.mcgill.a11y.image.request`. I have no idea how you would reasonably handle rewrites to the same field or fields here, and am open to discussion. Assigning @jeffbl and @shahdyousefak to look at the code, and including @jaydeepsingh25 for thoughts on caching. Feel free to un-assign yourselves once you've left a comment.


---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
