### PR TITLE
Configure SERVER_URL for tat at runtime

### DIFF
--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -24,14 +24,7 @@ ENV npm_config_ignore_scripts=true
 WORKDIR /app/packages/svgcanvas
 RUN npx rollup -c
 WORKDIR /app
-# Set server url based on registry tag
-ARG REGISTRY_TAG
-RUN if [ ${REGISTRY_TAG} = "unstable" ]; then \
-    npx rollup -c --environment SERVER_URL:"https://unicorn.cim.mcgill.ca/image/monarch/"; \
-else \
-    npx rollup -c --environment SERVER_URL:"https://image.a11y.mcgill.ca/monarch/"; \
-fi
-
+RUN npx rollup -c
 
 # Stage 2: Serve the application
 FROM nginx:alpine
@@ -51,5 +44,5 @@ EXPOSE 80
 # Healthcheck
 HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 CMD curl -f http://localhost/healthcheck.html || exit 1
 
-# Start the Nginx server
-CMD ["nginx", "-g", "daemon off;"]
+# Create config.js and start the Nginx server
+CMD sh -c "echo \"window.APP_CONFIG = { serverUrl: '\${SERVER_URL}' };\" > /usr/share/nginx/html/config.js && nginx -g 'daemon off;'"

--- a/test-docker-compose.yml
+++ b/test-docker-compose.yml
@@ -127,4 +127,4 @@ services:
       - "traefik.http.routers.tat.tls.certresolver=myresolver"
       - traefik.docker.network=traefik
     environment:
-      - SERVER_NAME=unicorn.cim.mcgill.ca
+      - SERVER_URL=https://unicorn.cim.mcgill.ca/image/


### PR DESCRIPTION
Changes have been made to the Dockerfile and test-docker-compose.yml to:
1. Create an environment variable SERVER_URL in test-docker-compose (SERVER_NAME was not being used and has hence been removed)
2. Remove hardcoded server urls in Dockerfile. Instead command creates a config.js at run using the environment variable, and this is picked up by the application.

**NOTE:** Please merge this PR _after_ Shared-Reality-Lab/IMAGE-TactileAuthoring#15 is merged. 

TESTING:
Tested that the tat is able to update content to the correct server based on the environment variable value SERVER_URL using override (tested by swapping between prod and dev server urls). The version of tat on IMAGE-TactileAuthoring branch server_url was used for this. `docker compose up -d tat --no-build` was used to ensure that the image is not rebuilt after when these swaps were made. 

Closes #1059 

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
