### PR TITLE
Add schema for pseudo-preprocessor body

### DIFF
--- a/preprocessors/modify-request.schema.json
+++ b/preprocessors/modify-request.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://image.a11y.mcgill.ca/preprocessors/modify-request.schema.json",
+    "type": "object",
+    "title": "Request Modification",
+    "description": "Pseudo-preprocessor: the key-value pairs in the body will be used to update those in the request, prior to it being sent to regular preprocessors. The ca.mcgill.a11y.image.request name and modifyRequest flag must be present.",
+    "not": {
+        "anyOf": [
+            { "required": ["request_uuid"] },
+            { "required": ["timestamp"] },
+            { "required": ["preprocessors"] }
+        ]
+    }
+}


### PR DESCRIPTION
Include a schema for the `ca.mcgill.a11y.image.request` responses from pseudo-preprocessors. Note that any key-value pairs are allowed, except for those that are protected (e.g., `request_uuid`). This is for pseudo-preprocessors to validate against. Tested with sample responses.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
