### PR TITLE
Remove rollup steps from tat service Dockerfile

### DIFF
--- a/services/tat/Dockerfile
+++ b/services/tat/Dockerfile
@@ -18,13 +18,13 @@ WORKDIR /app
 # RUN npm run build
 
 # Set npm to ignore scripts
-ENV npm_config_ignore_scripts=true
+# ENV npm_config_ignore_scripts=true
 
 # Run build manually ignoring scripts
-WORKDIR /app/packages/svgcanvas
-RUN npx rollup -c
-WORKDIR /app
-RUN npx rollup -c
+# WORKDIR /app/packages/svgcanvas
+# RUN npx rollup -c
+# WORKDIR /app
+# RUN npx rollup -c
 
 # Stage 2: Serve the application
 FROM nginx:alpine


### PR DESCRIPTION
With the changes made in Shared-Reality-Lab/IMAGE-TactileAuthoring#16, the rollup steps need to be removed from the IMAGE tat service Dockerfile. This PR comments out the corresponding lines in the Dockerfile.

NOTE: This needs to be merged after the PR Shared-Reality-Lab/IMAGE-TactileAuthoring#16 is merged and built!

TESTING: These changes were tested by using an override on unicorn along with the changes made in the PR linked above and ensuring that the build works and pushes data correctly to the Monarch with [this photo](https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg) and a hand drawn example (a rectangle labelled 'test').

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
