### PR TITLE
updating the text-followup preprocessor to target ollama generate endpoint

### DIFF
--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -408,25 +408,26 @@ def warmup():
     This avoids first-request latency by sending a dummy request.
     """
     try:
-        # construct the target Ollama endpoint for chat
-        api_url = f"{os.environ['OLLAMA_URL']}/chat"
+        # construct the target Ollama endpoint for generate
+        api_url = f"{os.environ['OLLAMA_URL']}/generate"
 
         # authorization headers with API key
         headers = {
-            "Authorization": f"Bearer {os.environ['OLLAMA_API_KEY']}"
+            "Authorization": f"Bearer {os.environ['OLLAMA_API_KEY']}",
+            "Content-Type": "application/json"
         }
 
         # prepare the warmup request data using the configured model
         data = {
             "model": os.environ["OLLAMA_MODEL"],
-            "messages": [{"role": "user", "content": "warmup"}],
-            "stream": False
+            "prompt": "ping",
+            "stream": False,
+            "keep_alive": -1  # instruct Ollama to keep the model in memory
         }
 
         logging.info("[WARMUP] Warmup endpoint triggered.")
-        logging.pii(
-            f"[WARMUP] Posting to {api_url} with model {data['model']}"
-        )
+        logging.pii(f"[WARMUP] Posting to {api_url} with model \
+                    {data['model']}")
 
         # send warmup request (with timeout)
         r = requests.post(api_url, headers=headers, json=data, timeout=60)
@@ -435,8 +436,7 @@ def warmup():
         return jsonify({"status": "warmed"}), 200
 
     except Exception as e:
-        logging.pii(f"[WARMUP] Warmup failed: {str(e)}")
-        logging.exception("[WARMUP] Exception details:")
+        logging.exception(f"[WARMUP] Exception details: {str(e)}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 


### PR DESCRIPTION
Bug fix: 

[Warmup] Waiting for image-text-followup-1 to be healthy...
[Warmup] image-text-followup-1 marked healthy. Waiting 10s before hitting warmup...
[Warmup] Hitting warmup endpoint at http://localhost:5000/warmup...
[Warmup] image-text-followup-1 warmup failed with HTTP 500. Response was:
{"message":"403 Client Error: Forbidden for url: https://ollama.pegasus.cim.mcgill.ca/ollama/api/chat","status":"error"}

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
