### PR TITLE
Move SERVERS env to osm preprocessor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,7 @@ services:
       ca.mcgill.a11y.image.optional_dependencies: ""
     environment:
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
+      - SERVERS=https://pegasus.cim.mcgill.ca/overpass/api/interpreter?
 
   object-sorting:
     profiles: [production, test, default]
@@ -557,7 +558,6 @@ services:
         - sc-store:/tmp/sc-store
     environment:
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
-      - SERVERS=https://pegasus.cim.mcgill.ca/overpass/api/interpreter?
 
   svg-open-street-map-handler:
     profiles: [test, default]


### PR DESCRIPTION
The SERVERS env was erroneously added to osm-streets-handler instead of openstreetmap. This PR fixes the issue. 

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
