### PR TITLE
Add environment-configurable Nominatim server with fallback + refactor request logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -412,7 +412,8 @@ services:
     environment:
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
       - NOMINATIM_SERVER=https://pegasus.cim.mcgill.ca/nominatim
-      - NOMINATIM_FALLBACK_SERVER=https://nominatim.openstreetmap.org
+      # Optional fallback if Pegasus is unreachable
+      # - NOMINATIM_FALLBACK_SERVER=https://nominatim.openstreetmap.org
   
   photo-tactile-svg-handler:
     profiles: [production, test, default]

--- a/preprocessors/nominatim/src/server.ts
+++ b/preprocessors/nominatim/src/server.ts
@@ -51,7 +51,7 @@ app.post("/preprocessor", async (req, res) => {
         return;
     }
 
-    //extract coordinates and enviroment urls
+    //extract coordinates and environment urls
     const coordinates = req.body["coordinates"];
     const nominatimServer = process.env.NOMINATIM_SERVER;
     const fallbackServer = process.env.NOMINATIM_FALLBACK_SERVER;

--- a/prod-docker-compose.yml
+++ b/prod-docker-compose.yml
@@ -65,3 +65,8 @@ services:
       - traefik.docker.network=traefik
     environment:
       - SERVER_URL=https://image.a11y.mcgill.ca/
+
+  nominatim-preprocessor:
+    environment:
+      # temporary: backup server in place for NFB
+      - NOMINATIM_FALLBACK_SERVER=https://nominatim.openstreetmap.org


### PR DESCRIPTION
Previously, the Pegasus-hosted Nominatim instance was not even running, and the preprocessor had no mechanism to target it. As a result, all reverse geocoding requests silently defaulted to the public OpenStreetMap endpoint. This ensures the Pegasus instance is explicitly targeted if available, and falls back to the public server only when necessary. 
 These are modifiable parameters in the docker-compose.yml.

Additionally,
I modified the `nominatim server.ts` by refactoring server.ts to use these variables rather than relying on hardcoded defaults. I also refactored towards a linear, easier-to-read structure with fallback support and eliminated the nested then logic, which more easily supports fallback logic; failures at both the primary and fallback endpoints  are explicit and traceable.

shahdy@unicorn:/var/docker/image$ docker logs 146efe153339
warn: Environment Unicorn: PII logging enabled!
Started server on port 80
Received request
Sending request to https://pegasus.cim.mcgill.ca/nominatim/reverse?lat=45.5048&lon=-73.5772&format=jsonv2
Valid response generated.

[within the container]
 shahdy@unicorn:/var/docker/image$ docker exec -it 146efe153339 sh 
/usr/src/app $ curl http://localhost/preprocessor \
>  -H “Content-Type: application/json” \
>  -d ‘{
>   “request_uuid”: “ee205039-13a0-494d-aacb-011850256d04”,
>   “timestamp”: 1720000000,
>   “language”: “en”,
>   “coordinates”: {
>    “latitude”: 45.5048,
>    “longitude”: -73.5772
>   },
>   “context”: “<source></source>“,
>   “capabilities”: [“ca.mcgill.keyboard”, “ca.mcgill.screenreader”],
>   “renderers”: [“ca.mcgill.sonification”, “ca.mcgill.tactile”]
>  }’
{“request_uuid”:“ee205039-13a0-494d-aacb-011850256d04",“timestamp”:1750352635,“name”:“ca.mcgill.a11y.image.preprocessor.nominatim”,“data”:{“place_id”:59559396,“licence”:“Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright”,“osm_type”:“node”,“osm_id”:11289783515,“lat”:“45.5047661",“lon”:“-73.5772115",“category”:“leisure”,“type”:“picnic_table”,“place_rank”:30,“importance”:0.00000999999999995449,“addresstype”:“leisure”,“name”:“”,“display_name”:“845, Rue Sherbrooke Ouest, Ville-Marie, Montréal, Agglomération de Montréal, Montréal (région administrative), Québec, H3A 3G4, Canada”,“address”:{“house_number”:“845”,“road”:“Rue Sherbrooke Ouest”,“suburb”:“Ville-Marie”,“city”:“Montréal”,“county”:“Agglomération de Montréal”,“region”:“Montréal (région administrative)“,”state”:“Québec”,“ISO3166-2-lvl4":“CA-QC”,“postcode”:“H3A 3G4”,“country”:“Canada”,“country_code”:“ca”},“boundingbox”:[“45.5047161”,“45.5048161",“-73.5772615”,“-73.5771615"]}}/usr/src/app $


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [X] I described the changes made and how these address the issue.
- [X] I described how I tested these changes.

## Coding/Commit Requirements

* [X] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [X] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`. --> added environment vars
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [X] I have not added a new component in this PR.
