### PR TITLE
resize-graphic healthcheck: correcting healthcheck port

### DIFF
--- a/preprocessors/resize-graphic/Dockerfile
+++ b/preprocessors/resize-graphic/Dockerfile
@@ -39,7 +39,7 @@ EXPOSE 80
 USER python
 
 # Define the healthcheck command
-HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 CMD curl -f http://localhost:5000/health || exit 1
+HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 CMD curl -f http://localhost:80/health || exit 1
 
 # Define the command to run the application using gunicorn
 CMD [ "gunicorn", "resize-graphic:app", "-b", "0.0.0.0:80", "--capture-output", "--timeout=120", "--log-level=debug" ]


### PR DESCRIPTION
shahdy@unicorn:/var/docker/image$ docker ps | grep resize
92884a12f2db   ghcr.io/shared-reality-lab/image-preprocessor-resize-graphic:unstable                    "gunicorn resize-gra…"   7 minutes ago   Up 7 minutes (unhealthy)   80/tcp                                                                         image-resize-graphic-1

Flask app is served on port 80, but the health check was probing port 5000.


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Don't delete below this line.

---

## Required Information

- [] I referenced the issue addressed in this PR.
- [X] I described the changes made and how these address the issue.
- [X] I described how I tested these changes.

## Coding/Commit Requirements

* [X] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [X] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [X] I have not added a new component in this PR.
