### PR TITLE
imageup to run on Pegasus (production), just not when triggered by cron 

### DIFF
--- a/scripts/image_daily_cron
+++ b/scripts/image_daily_cron
@@ -21,8 +21,8 @@ if [ ! -x "$IMAGEUP" ] || [ ! -x "$PP_DAILY_TEST" ]; then
   exit 1
 fi
 
-# Run imageup with --auto to indicate this is a cron-triggered run
-"$IMAGEUP" --auto > "$LOG_DIR/imageup.$(date "+%Y.%m.%d-%H.%M.%S")" 2>&1
+# Run imageup with --service to indicate this is a cron-triggered run
+"$IMAGEUP" --service > "$LOG_DIR/imageup.$(date "+%Y.%m.%d-%H.%M.%S")" 2>&1
 
 # Run pp_daily_test
 "$PP_DAILY_TEST"

--- a/scripts/image_daily_cron
+++ b/scripts/image_daily_cron
@@ -21,8 +21,8 @@ if [ ! -x "$IMAGEUP" ] || [ ! -x "$PP_DAILY_TEST" ]; then
   exit 1
 fi
 
-# Run imageup
-"$IMAGEUP" > "$LOG_DIR/imageup.$(date "+%Y.%m.%d-%H.%M.%S")" 2>&1
+# Run imageup with --auto to indicate this is a cron-triggered run
+"$IMAGEUP" --auto > "$LOG_DIR/imageup.$(date "+%Y.%m.%d-%H.%M.%S")" 2>&1
 
 # Run pp_daily_test
 "$PP_DAILY_TEST"

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -27,6 +27,12 @@ if [[ -z "$COMPOSE_ENV_FILE" || -z "$ENVIRONMENT" ]]; then
   exit 1
 fi
 
+# Skip automatic daily resets in production (we use Pegasus)
+if [[ "$1" == "--auto" && "$ENVIRONMENT" == "production" ]]; then
+  echo "$(date) - Skipping imageup: auto-run skipped in production" >> /tmp/imageup_skip.log
+  exit 0
+fi
+
 delete_override=true  # default to deleting override file
 
 # get command line arguments

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -27,21 +27,31 @@ if [[ -z "$COMPOSE_ENV_FILE" || -z "$ENVIRONMENT" ]]; then
   exit 1
 fi
 
-# Skip automatic daily resets in production (we use Pegasus)
-if [[ "$1" == "--auto" && "$ENVIRONMENT" == "production" ]]; then
-  echo "$(date) - Skipping imageup: auto-run skipped in production" >> /tmp/imageup_skip.log
+# parse flags
+delete_override=true # default to deleting override file
+is_service_run=false # whether the script was invoked by a system/cron job
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -k|--keep)
+      delete_override=false
+      ;;
+    --service)
+      is_service_run=true
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Skip service-triggered runs in production (we use Pegasus)
+if [[ "$is_service_run" == true && "$ENVIRONMENT" == "production" ]]; then
+  echo "$(date) - Skipping imageup: service-run skipped in production" >&2
   exit 0
 fi
-
-delete_override=true  # default to deleting override file
-
-# get command line arguments
-#  https://stackoverflow.com/questions/7069682/how-to-get-arguments-with-flags-in-bash/21128172
-while getopts 'k' flag; do
-  case "${flag}" in
-    k) delete_override='false' ;;
-  esac
-done
 
 set -o errexit # halt script if anything returns error
 if [ "$delete_override" = true ]; then


### PR DESCRIPTION
We want imageup to run on production (Pegasus), but we do not want it to be run automatically via image_daily_cron on production. Now, we are relying on the cron script itself (image_daily_cron) to control where it runs (test machines only).

imageup --auto will not run on production servers, but manual runs of imageup (without --auto) will still work on production just fine.

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
