### PR TITLE
Change IMAGE page address in allowed origins

### DIFF
--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -46,7 +46,7 @@ app = Flask(__name__)
 
 # --- Configuration ---
 ALLOWED_ORIGINS = [
-    "https://image.a11y.mcgill.ca/",
+    "https://image.a11y.mcgill.ca/pages/multistage_diagrams.html",
     "https://venissacarolquadros.github.io/",
     "https://unicorn.cim.mcgill.ca/",
 ]


### PR DESCRIPTION
Changed the IMAGE address in `ALLOWED_ORIGINS` from the main website URL to the specific page with multistage diagram examples.
This prevents the `multistage-diagram-segmentation` preprocessor from triggering when the extension is used on the graphics from the front page.
Tested on Unicorn with override.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
