### PR TITLE
schema update behind update_schemas=true with optional --no-update-schemas overide

### DIFF
--- a/scripts/imageup
+++ b/scripts/imageup
@@ -30,7 +30,7 @@ fi
 # parse flags
 delete_override=true # default to deleting override file
 is_service_run=false # whether the script was invoked by a system/cron job
-update_schemas=true # whether to update the schemas submodule to latest from origin/schemas 
+update_schemas=false # whether to update the schemas submodule to latest from origin/schemas 
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -92,11 +92,19 @@ git reset --hard origin/main
 git pull
 git submodule update --init
 
+# Check if schemas submodule is behind
+schemas_local=$(cd schemas && git rev-parse HEAD)
+schemas_remote=$(git ls-remote origin refs/heads/schemas | cut -f1)
+
+if [[ "$schemas_local" != "$schemas_remote" ]]; then
+  echo "Schemas submodule is not at the most current version."
+  echo "To update, re-run imageup with --update-schemas (after staging code changes if needed)."
+fi
 
 # Update schemas submodule to latest origin/schemas and commit the pointer
 if [ "$update_schemas" = true ]; then
   echo "Updating schemas submodule using git submodule update --remote..."
- 
+
   # fetches the latest commit on 'schemas' branch (as per .gitmodules config, branch = schemas)
   git submodule update --remote schemas
 
@@ -107,10 +115,10 @@ if [ "$update_schemas" = true ]; then
   # commit updated pointer in main repo
   git add schemas
   git commit -m "Bump schemas submodule to ${new_hash:0:7}" || echo "No changes to commit."
+  echo "Reminder: Don't forget to push the schemas submodule bump if committed!"
 else
   echo "Skipping schemas submodule update (update_schemas=false)"
 fi
-
 
 # Pull the latest built images
 docker compose --env-file "$COMPOSE_ENV_FILE" pull
@@ -148,3 +156,4 @@ echo "Running warmup for critical services..."
 "${SCRIPT_DIR}/warmup"
 
 cd -
+

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -30,6 +30,7 @@ fi
 # parse flags
 delete_override=true # default to deleting override file
 is_service_run=false # whether the script was invoked by a system/cron job
+update_schemas=true # whether to update the schemas submodule to latest from origin/schemas 
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -38,6 +39,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --service)
       is_service_run=true
+      ;;
+    --no-update-schemas)
+      update_schemas=false
       ;;
     *)
       echo "Unknown option: $1" >&2
@@ -87,6 +91,27 @@ git fetch origin
 git reset --hard origin/main
 git pull
 git submodule update --init
+
+if [ "$update_schemas" = true ]; then
+  echo "Checking schemas submodule for updates..."
+  cd "$IMAGE_SERVER_DIR/schemas"
+  git fetch origin schemas
+  current_hash=$(git rev-parse HEAD)
+  latest_hash=$(git rev-parse origin/schemas)
+
+  if [ "$current_hash" != "$latest_hash" ]; then
+    echo "Schemas submodule is behind by commits."
+    echo "Latest commit: ${latest_hash:0:7} — your checkout: ${current_hash:0:7}"
+    echo "Updating schemas submodule to latest..."
+    git checkout schemas
+    git pull origin schemas
+    cd "$IMAGE_SERVER_DIR"
+    git add schemas
+    git commit -m "Bump schemas submodule to ${latest_hash:0:7}" || echo "No changes to commit."
+  else
+    echo "Schemas submodule is up-to-date (${current_hash:0:7})"
+  fi
+fi
 
 # Pull the latest built images
 docker compose --env-file "$COMPOSE_ENV_FILE" pull

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -95,21 +95,18 @@ git submodule update --init
 
 # Update schemas submodule to latest origin/schemas and commit the pointer
 if [ "$update_schemas" = true ]; then
-  echo "Checking schemas submodule for updates..."
-  cd "$IMAGE_SERVER_DIR/schemas"
-  git fetch origin schemas
-  git checkout schemas
-  git pull origin schemas
+  echo "Updating schemas submodule using git submodule update --remote..."
+ 
+  # fetches the latest commit on 'schemas' branch (as per .gitmodules config, branch = schemas)
+  git submodule update --remote schemas
 
-  new_hash=$(git rev-parse HEAD)
+  # grab latest commit hash of schemas submodule
+  new_hash=$(cd schemas && git rev-parse HEAD)
   echo "Updated schemas submodule to ${new_hash:0:7}"
 
-  cd "$IMAGE_SERVER_DIR"
-  
-  # updates the pointer in .gitmodules + index to tell main to now track that new commit in the schemas submodule.
+  # commit updated pointer in main repo
   git add schemas
   git commit -m "Bump schemas submodule to ${new_hash:0:7}" || echo "No changes to commit."
-
 else
   echo "Skipping schemas submodule update (update_schemas=false)"
 fi

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -40,8 +40,8 @@ while [[ $# -gt 0 ]]; do
     --service)
       is_service_run=true
       ;;
-    --no-update-schemas)
-      update_schemas=false
+    --update-schemas)
+      update_schemas=true
       ;;
     *)
       echo "Unknown option: $1" >&2

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -98,7 +98,7 @@ schemas_remote=$(git ls-remote origin refs/heads/schemas | cut -f1)
 
 if [[ "$schemas_local" != "$schemas_remote" ]]; then
   echo "Schemas submodule is not at the most current version."
-  echo "To update, re-run imageup with --update-schemas (after staging code changes if needed)."
+  echo "To update, re-run imageup with --update-schemas."
 fi
 
 # Update schemas submodule to latest origin/schemas and commit the pointer

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -115,7 +115,8 @@ if [ "$update_schemas" = true ]; then
   # commit updated pointer in main repo
   git add schemas
   git commit -m "Bump schemas submodule to ${new_hash:0:7}" || echo "No changes to commit."
-  echo "Reminder: Don't forget to push the schemas submodule bump if committed!"
+  echo "Pushing updated schemas submodule pointer to origin/main..."
+  git push origin main
 else
   echo "Skipping schemas submodule update (update_schemas=false)"
 fi

--- a/scripts/imageup
+++ b/scripts/imageup
@@ -92,26 +92,28 @@ git reset --hard origin/main
 git pull
 git submodule update --init
 
+
+# Update schemas submodule to latest origin/schemas and commit the pointer
 if [ "$update_schemas" = true ]; then
   echo "Checking schemas submodule for updates..."
   cd "$IMAGE_SERVER_DIR/schemas"
   git fetch origin schemas
-  current_hash=$(git rev-parse HEAD)
-  latest_hash=$(git rev-parse origin/schemas)
+  git checkout schemas
+  git pull origin schemas
 
-  if [ "$current_hash" != "$latest_hash" ]; then
-    echo "Schemas submodule is behind by commits."
-    echo "Latest commit: ${latest_hash:0:7} — your checkout: ${current_hash:0:7}"
-    echo "Updating schemas submodule to latest..."
-    git checkout schemas
-    git pull origin schemas
-    cd "$IMAGE_SERVER_DIR"
-    git add schemas
-    git commit -m "Bump schemas submodule to ${latest_hash:0:7}" || echo "No changes to commit."
-  else
-    echo "Schemas submodule is up-to-date (${current_hash:0:7})"
-  fi
+  new_hash=$(git rev-parse HEAD)
+  echo "Updated schemas submodule to ${new_hash:0:7}"
+
+  cd "$IMAGE_SERVER_DIR"
+  
+  # updates the pointer in .gitmodules + index to tell main to now track that new commit in the schemas submodule.
+  git add schemas
+  git commit -m "Bump schemas submodule to ${new_hash:0:7}" || echo "No changes to commit."
+
+else
+  echo "Skipping schemas submodule update (update_schemas=false)"
 fi
+
 
 # Pull the latest built images
 docker compose --env-file "$COMPOSE_ENV_FILE" pull


### PR DESCRIPTION
By default, the script will now check whether the schemas submodule is up to date with origin/schemas, and update it if it is behind.
New flag logic added: `update_schemas=true` is the default, with an optional override with `--no-update-schemas`

-> update the schemas submodule to the latest commit on the origin/schemas branch and commit that new submodule pointer into main


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
