### PR TITLE
Push to production (new script: tag_and_deploy)

### DIFF
--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -115,17 +115,22 @@ parse_workflow_tag_patterns # fill COMPONENT_TAG_PREFIXES with mappings from wor
 
 echo "Tagging components..."
 
+# case: tag orchestrator root
+if echo "$TAG_AND_DEPLOY_ENABLED_DIRS" | grep -qw "orchestrator"; then
+  [ -d "orchestrator" ] && tag_component "orchestrator"
+fi
+
 # Loop through all defined base directories (like preprocessors/, handlers/)
 for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
   for COMPONENT in "$DIR"/*; do
+    # Skip orchestrator - it's tagged above
+    if [[ "$COMPONENT" == "orchestrator/"* ]]; then
+      continue
+    fi
     [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
   done
 done
 
-# case: tag orchestrator directly
-if echo "$TAG_AND_DEPLOY_ENABLED_DIRS" | grep -qw "orchestrator"; then
-  [ -d "orchestrator" ] && tag_component "orchestrator"
-fi
 
 echo "Done. Check workflows at:"
 echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -30,7 +30,7 @@ cd "$ROOT_DIR" || exit 1
 : "${TAG_AND_DEPLOY_GIT_REMOTE:?}"
 : "${TAG_AND_DEPLOY_ENABLED_DIRS:=preprocessors handlers services orchestrator}"
 
-# explicitly passed services (1 or more) to tag (e.g., preprocessors/semantic-segmentation)
+# explicitly passed services (1 or more) to tag (e.g., preprocessors/mmsemseg)
 EXPLICIT_SERVICES=("$@")
 
 # declare an associative array (key-value map)

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -132,15 +132,15 @@ git pull origin main
 echo "Parsing GitHub workflow tag patterns..."
 parse_workflow_tag_patterns # fill COMPONENT_TAG_PREFIXES with mappings from workflows
 
-echo "Tagging services..."
+echo "Tagging components..."
 
-if [ "${#EXPLICIT_SERVICES[@]}" -gt 0 ]; then
-  echo "Explicit services provided: ${EXPLICIT_SERVICES[*]}"
-  for SERVICE in "${EXPLICIT_SERVICES[@]}"; do
-    if [ -d "$SERVICE" ]; then
-      tag_component "$SERVICE"
+if [ "${#EXPLICIT_COMPONENTS[@]}" -gt 0 ]; then
+  echo "Explicit components provided: ${EXPLICIT_COMPONENTS[*]}"
+  for COMPONENT in "${EXPLICIT_COMPONENTS[@]}"; do
+    if [ -d "$COMPONENT" ]; then
+      tag_component "$COMPONENT"
     else
-      echo "Warning: Service path not found: $SERVICE"
+      echo "Warning: Component path not found: $COMPONENT"
     fi
   done
 else

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -114,12 +114,18 @@ echo "Parsing GitHub workflow tag patterns..."
 parse_workflow_tag_patterns # fill COMPONENT_TAG_PREFIXES with mappings from workflows
 
 echo "Tagging components..."
+
 # Loop through all defined base directories (like preprocessors/, handlers/)
 for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
   for COMPONENT in "$DIR"/*; do
     [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
   done
 done
+
+# case: tag orchestrator directly
+if echo "$TAG_AND_DEPLOY_ENABLED_DIRS" | grep -qw "orchestrator"; then
+  [ -d "orchestrator" ] && tag_component "orchestrator"
+fi
 
 echo "Done. Check workflows at:"
 echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -115,18 +115,19 @@ tag_component() {
   fi
 
   LATEST_TAG=$(git tag -l "${TAG_PREFIX}-*" | sort -V | tail -n1)
+
   if [ -z "$LATEST_TAG" ]; then
-    echo "No existing tags for $TAG_PREFIX, skipping."
-    return
+    echo "No existing tags for $TAG_PREFIX, starting at 0.0.1"
+    MAJOR=0
+    MINOR=0
+    PATCH=0
+  else
+    VERSION="${LATEST_TAG##*-}" # extract just the version (e.g., from service-tat-1.2.3, extract 1.2.3)
+    MAJOR=$(echo "$VERSION" | cut -d. -f1)
+    MINOR=$(echo "$VERSION" | cut -d. -f2)
+    PATCH=$(echo "$VERSION" | cut -d. -f3)
   fi
 
-  VERSION="${LATEST_TAG##*-}" # extract just the version (e.g., from service-tat-1.2.3, extract 1.2.3)
-  # Break version into components: MAJOR.MINOR.PATCH
-  MAJOR=$(echo "$VERSION" | cut -d. -f1)
-  MINOR=$(echo "$VERSION" | cut -d. -f2)
-  PATCH=$(echo "$VERSION" | cut -d. -f3)
-
-  
   #  bump logic based on selected --bump-* flag
   case "$BUMP_TYPE" in
     major)

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -2,6 +2,10 @@
 
 # tag_and_deploy
 # Tags IMAGE-server components that match GitHub Actions workflows with tag triggers
+# Usage:
+#	./scripts/tag_and_deploy # tags all services
+#	./scripts/tag_and_deploy services/tat # tags 1+ services
+
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -26,6 +30,8 @@ cd "$ROOT_DIR" || exit 1
 : "${TAG_AND_DEPLOY_GIT_REMOTE:?}"
 : "${TAG_AND_DEPLOY_ENABLED_DIRS:=preprocessors handlers services orchestrator}"
 
+# explicitly passed services (1 or more) to tag (e.g., preprocessors/semantic-segmentation)
+EXPLICIT_SERVICES=("$@")
 
 # declare an associative array (key-value map)
 # e.g., COMPONENT_TAG_PREFIXES["services/tat"]="service-tat"
@@ -126,24 +132,32 @@ git pull origin main
 echo "Parsing GitHub workflow tag patterns..."
 parse_workflow_tag_patterns # fill COMPONENT_TAG_PREFIXES with mappings from workflows
 
-echo "Tagging components..."
+echo "Tagging services..."
 
-# case: tag orchestrator root
-if echo "$TAG_AND_DEPLOY_ENABLED_DIRS" | grep -qw "orchestrator"; then
-  [ -d "orchestrator" ] && tag_component "orchestrator"
-fi
-
-# Loop through all defined base directories (like preprocessors/, handlers/)
-for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
-  for COMPONENT in "$DIR"/*; do
-    # Skip orchestrator - it's tagged above
-    if [[ "$COMPONENT" == "orchestrator/"* ]]; then
-      continue
+if [ "${#EXPLICIT_SERVICES[@]}" -gt 0 ]; then
+  echo "Explicit services provided: ${EXPLICIT_SERVICES[*]}"
+  for SERVICE in "${EXPLICIT_SERVICES[@]}"; do
+    if [ -d "$SERVICE" ]; then
+      tag_component "$SERVICE"
+    else
+      echo "Warning: Service path not found: $SERVICE"
     fi
-    [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
   done
-done
-
+else
+# case: tag orchestrator root
+  if echo "$TAG_AND_DEPLOY_ENABLED_DIRS" | grep -qw "orchestrator"; then
+    [ -d "orchestrator" ] && tag_component "orchestrator"
+  fi
+# Loop through all defined base directories (like preprocessors/, handlers/)
+  for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
+    for COMPONENT in "$DIR"/*; do
+      if [[ "$COMPONENT" == "orchestrator/"* ]]; then
+        continue
+      fi
+      [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
+    done
+  done
+fi
 
 echo "Done. Check workflows at:"
 echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -16,6 +16,11 @@ else
   exit 1
 fi
 
+mkdir -p "$LOG_DIR"
+TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
+LOG_FILE="$LOG_DIR/tag_and_deploy.$TIMESTAMP"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 cd "$ROOT_DIR" || exit 1
 
 : "${TAG_AND_DEPLOY_GIT_REMOTE:?}"

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -8,7 +8,9 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="$ROOT_DIR/config/tag_and_deploy.env"
 
 if [ -f "$ENV_FILE" ]; then
-  export $(grep -v '^#' "$ENV_FILE" | xargs)
+  set -a
+  source <(grep -v '^#' "$ENV_FILE")
+  set +a
 else
   echo "Error: Environment file not found at $ENV_FILE" >&2
   exit 1

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -19,17 +19,45 @@ cd "$ROOT_DIR" || exit 1
 : "${TAG_AND_DEPLOY_GIT_REMOTE:?}"
 : "${TAG_AND_DEPLOY_ENABLED_DIRS:=preprocessors handlers services orchestrator}"
 
+
+# declare an associative array (key-value map)
+# e.g., COMPONENT_TAG_PREFIXES["services/tat"]="service-tat"
 declare -A COMPONENT_TAG_PREFIXES
 
+
 # parse_workflow_tag_patterns
-# Placeholder - this should populate COMPONENT_TAG_PREFIXES["path"]="prefix"
+# scans all .github/workflows/*.yml files and extracts:
+# - Tag prefix (e.g., service-tat-[0-9]+.[0-9]+.[0-9]+ -> service-tat)
+# - Watched directory (e.g., services/tat/** → services/tat) 
+# populates COMPONENT_TAG_PREFIXES[path]="prefix"
 parse_workflow_tag_patterns() {
-  # COMPONENT_TAG_PREFIXES["preprocessors/grouping"]="preprocessor-grouping"
-  :
+  WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+
+  # WF will hold the path to the current workflow file
+  for WF in "$WORKFLOW_DIR"/*.yml; do
+    
+    # the pattern used to match tags (e.g. "service-tat-[0-9]+.[0-9]+.[0-9]+")
+    TAG_REGEX=$(grep -E 'tags:\s+\[\s*"' "$WF" | grep -oE '"[^"]+"' | tr -d '"')
+    #  the path (e.g., "services/tat/**")
+    PATH_GLOB=$(grep -A2 'paths:' "$WF" | grep -oE '"[^"]+"' | head -1 | tr -d '"')
+    
+    # if either value was empty (workflow didnt define tags or paths), skip this file
+    [ -z "$TAG_REGEX" ] || [ -z "$PATH_GLOB" ] && continue
+
+    TAG_PREFIX=$(echo "$TAG_REGEX" | sed -E 's/-\[.*//') # trims the pattern to just "service-tat"
+    CLEAN_PATH=$(echo "$PATH_GLOB" | sed -E 's|/\*\*$||') # trims "**" from the directory path
+
+    # the script dynamically builds the correct tag-prefix map from the workflow files
+    # e.g., COMPONENT_TAG_PREFIXES["handlers/multistage-diagram-tactile-svg"]="handler-multistage-diagram-tactile-svg"
+    
+    COMPONENT_TAG_PREFIXES["$CLEAN_PATH"]="$TAG_PREFIX" # e.g., COMPONENT_TAG_PREFIXES["services/tat"] -> service-tat
+  done
 }
 
 # tag_component
-# Tags a component at HEAD using its latest known tag version
+# Given a directory path, looks up its tag prefix, finds the latest tag,
+# increments the patch version (1.2.3->1.2.4) and creates a new Git tag
+# if HEAD hasn’t already been tagged with it
 tag_component() {
   COMPONENT_PATH="$1"
   COMPONENT_NAME=$(basename "$COMPONENT_PATH")
@@ -42,14 +70,25 @@ tag_component() {
   fi
 
   LATEST_TAG=$(git tag -l "${TAG_PREFIX}-*" | sort -V | tail -n1)
-  [ -z "$LATEST_TAG" ] && echo "No existing tags for $TAG_PREFIX" && return
+  if [ -z "$LATEST_TAG" ]; then
+    echo "No existing tags for $TAG_PREFIX, skipping."
+    return
+  fi
 
-  VERSION="${LATEST_TAG##*-}"
-  NEW_TAG="${TAG_PREFIX}-${VERSION}"
+  VERSION="${LATEST_TAG##*-}" # extract just the version (e.g., from service-tat-1.2.3, extract 1.2.3)
+  # Break version into components: MAJOR.MINOR.PATCH
+  MAJOR=$(echo "$VERSION" | cut -d. -f1)
+  MINOR=$(echo "$VERSION" | cut -d. -f2)
+  PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+  NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+  NEW_TAG="${TAG_PREFIX}-${NEW_VERSION}"
 
   HEAD_COMMIT=$(git rev-parse HEAD)
   TAGGED_COMMIT=$(git rev-list -n 1 "$NEW_TAG" 2>/dev/null || echo "")
 
+
+  # If this tag doesn’t already exist at HEAD, create + push it
   if [ "$TAGGED_COMMIT" != "$HEAD_COMMIT" ]; then
     echo "Tagging $NEW_TAG at HEAD"
     git tag "$NEW_TAG"
@@ -59,15 +98,16 @@ tag_component() {
   fi
 }
 
-
+# - Main script execution begins here -
 echo "Updating main branch..."
 git checkout main >/dev/null 2>&1
 git pull origin main
 
 echo "Parsing GitHub workflow tag patterns..."
-parse_workflow_tag_patterns
+parse_workflow_tag_patterns # fill COMPONENT_TAG_PREFIXES with mappings from workflows
 
 echo "Tagging components..."
+# Loop through all defined base directories (like preprocessors/, handlers/)
 for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
   for COMPONENT in "$DIR"/*; do
     [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
@@ -76,4 +116,4 @@ done
 
 echo "Done. Check workflows at:"
 echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"
-
+echo "Please note, to complete deployment to Pegasus, run imageup after the above workflows complete! :)"

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -3,8 +3,11 @@
 # tag_and_deploy
 # Tags IMAGE-server components that match GitHub Actions workflows with tag triggers
 # Usage:
-#	./scripts/tag_and_deploy # tags all services
-#	./scripts/tag_and_deploy services/tat # tags 1+ services
+#	./scripts/tag_and_deploy                    # tags all components, bumps patch by default
+#	./scripts/tag_and_deploy --bump-minor       # tags all components, bumps minor
+#	./scripts/tag_and_deploy --bump-major       # tags all components, bumps major
+#	./scripts/tag_and_deploy services/tat       # tags one component (patch default) - can add more components to tag
+#	./scripts/tag_and_deploy --bump-minor services/tat handlers/multistage-diagram-tactile-svg # tags two components with minor bump
 
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -30,8 +33,37 @@ cd "$ROOT_DIR" || exit 1
 : "${TAG_AND_DEPLOY_GIT_REMOTE:?}"
 : "${TAG_AND_DEPLOY_ENABLED_DIRS:=preprocessors handlers services orchestrator}"
 
+# Parse optional version bump flags
+# Default: bump patch
+BUMP_TYPE="patch"
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bump-major)
+      BUMP_TYPE="major"
+      shift
+      ;;
+    --bump-minor)
+      BUMP_TYPE="minor"
+      shift
+      ;;
+    --bump-patch)
+      BUMP_TYPE="patch"
+      shift
+      ;;
+    -*)
+      echo "Unknown flag: $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
 # explicitly passed services (1 or more) to tag (e.g., preprocessors/mmsemseg)
-EXPLICIT_SERVICES=("$@")
+EXPLICIT_COMPONENTS=("${POSITIONAL_ARGS[@]}") # filters out flags
 
 # declare an associative array (key-value map)
 # e.g., COMPONENT_TAG_PREFIXES["services/tat"]="service-tat"
@@ -94,25 +126,28 @@ tag_component() {
   MINOR=$(echo "$VERSION" | cut -d. -f2)
   PATCH=$(echo "$VERSION" | cut -d. -f3)
 
-
-  # cascading incrementing from the latest existing tag
-  PATCH=$((PATCH + 1))
-  if [ "$PATCH" -ge 10 ]; then
-    PATCH=0
-    MINOR=$((MINOR + 1))
-    if [ "$MINOR" -ge 10 ]; then
-      MINOR=0
+  
+  #  bump logic based on selected --bump-* flag
+  case "$BUMP_TYPE" in
+    major)
       MAJOR=$((MAJOR + 1))
-    fi
-  fi
+      MINOR=0
+      PATCH=0
+      ;;
+    minor)
+      MINOR=$((MINOR + 1))
+      PATCH=0
+      ;;
+    patch)
+      PATCH=$((PATCH + 1))
+      ;;
+  esac
 
   NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-
   NEW_TAG="${TAG_PREFIX}-${NEW_VERSION}"
 
   HEAD_COMMIT=$(git rev-parse HEAD)
   TAGGED_COMMIT=$(git rev-list -n 1 "$NEW_TAG" 2>/dev/null || echo "")
-
 
   # If this tag doesn’t already exist at HEAD, create + push it
   if [ "$TAGGED_COMMIT" != "$HEAD_COMMIT" ]; then
@@ -162,3 +197,4 @@ fi
 echo "Done. Check workflows at:"
 echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"
 echo "Please note, to complete deployment to Pegasus, run imageup after the above workflows complete! :)"
+

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# tag_and_deploy
+# Tags IMAGE-server components that match GitHub Actions workflows with tag triggers
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$ROOT_DIR/config/tag_and_deploy.env"
+
+if [ -f "$ENV_FILE" ]; then
+  export $(grep -v '^#' "$ENV_FILE" | xargs)
+else
+  echo "Error: Environment file not found at $ENV_FILE" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR" || exit 1
+
+: "${TAG_AND_DEPLOY_GIT_REMOTE:?}"
+: "${TAG_AND_DEPLOY_ENABLED_DIRS:=preprocessors handlers services orchestrator}"
+
+declare -A COMPONENT_TAG_PREFIXES
+
+# parse_workflow_tag_patterns
+# Placeholder - this should populate COMPONENT_TAG_PREFIXES["path"]="prefix"
+parse_workflow_tag_patterns() {
+  # COMPONENT_TAG_PREFIXES["preprocessors/grouping"]="preprocessor-grouping"
+  :
+}
+
+# tag_component
+# Tags a component at HEAD using its latest known tag version
+tag_component() {
+  COMPONENT_PATH="$1"
+  COMPONENT_NAME=$(basename "$COMPONENT_PATH")
+  [ "$COMPONENT_NAME" = "deprecated" ] && return
+
+  TAG_PREFIX="${COMPONENT_TAG_PREFIXES[$COMPONENT_PATH]}"
+  if [ -z "$TAG_PREFIX" ]; then
+    echo "Skipping $COMPONENT_PATH: no matching workflow tag"
+    return
+  fi
+
+  LATEST_TAG=$(git tag -l "${TAG_PREFIX}-*" | sort -V | tail -n1)
+  [ -z "$LATEST_TAG" ] && echo "No existing tags for $TAG_PREFIX" && return
+
+  VERSION="${LATEST_TAG##*-}"
+  NEW_TAG="${TAG_PREFIX}-${VERSION}"
+
+  HEAD_COMMIT=$(git rev-parse HEAD)
+  TAGGED_COMMIT=$(git rev-list -n 1 "$NEW_TAG" 2>/dev/null || echo "")
+
+  if [ "$TAGGED_COMMIT" != "$HEAD_COMMIT" ]; then
+    echo "Tagging $NEW_TAG at HEAD"
+    git tag "$NEW_TAG"
+    git push origin "refs/tags/$NEW_TAG"
+  else
+    echo "$NEW_TAG already exists at HEAD"
+  fi
+}
+
+
+echo "Updating main branch..."
+git checkout main >/dev/null 2>&1
+git pull origin main
+
+echo "Parsing GitHub workflow tag patterns..."
+parse_workflow_tag_patterns
+
+echo "Tagging components..."
+for DIR in $TAG_AND_DEPLOY_ENABLED_DIRS; do
+  for COMPONENT in "$DIR"/*; do
+    [ -d "$COMPONENT" ] && tag_component "$COMPONENT"
+  done
+done
+
+echo "Done. Check workflows at:"
+echo "  https://github.com/Shared-Reality-Lab/IMAGE-server/actions"
+

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -88,7 +88,20 @@ tag_component() {
   MINOR=$(echo "$VERSION" | cut -d. -f2)
   PATCH=$(echo "$VERSION" | cut -d. -f3)
 
-  NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+  # cascading incrementing from the latest existing tag
+  PATCH=$((PATCH + 1))
+  if [ "$PATCH" -ge 10 ]; then
+    PATCH=0
+    MINOR=$((MINOR + 1))
+    if [ "$MINOR" -ge 10 ]; then
+      MINOR=0
+      MAJOR=$((MAJOR + 1))
+    fi
+  fi
+
+  NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
   NEW_TAG="${TAG_PREFIX}-${NEW_VERSION}"
 
   HEAD_COMMIT=$(git rev-parse HEAD)

--- a/scripts/tag_and_deploy
+++ b/scripts/tag_and_deploy
@@ -90,7 +90,7 @@ tag_component() {
 
   # If this tag doesn’t already exist at HEAD, create + push it
   if [ "$TAGGED_COMMIT" != "$HEAD_COMMIT" ]; then
-    echo "Tagging $NEW_TAG at HEAD"
+    echo "Tagging $TAG_PREFIX: $VERSION -> $NEW_VERSION at HEAD"
     git tag "$NEW_TAG"
     git push origin "refs/tags/$NEW_TAG"
   else


### PR DESCRIPTION
scripts/tag_and_deploy

- Parses all GitHub workflow files to figure out what components need versioned tags.
- Identifies the most recent tag for each component (by directory).
- Creates a new tag with an incremented patch version (e.g. 1.2.3 → 1.2.4).
- Pushes that tag to GitHub, triggering the corresponding GitHub Action workflow for that component.

You can run it either:

- with no args -- tags everything (preprocessors, handlers, services, orchestrator)
- with a specific path, e.g., ./scripts/tag_and_deploy services/tat, to tag only that component.

The script's output is logged in /var/docker/image/testing/tag-and-deploy, which is adjacent to how the rest of our scripts log.

Sample output:

```
shahdy@unicorn:~/IMAGE-server$ ./scripts/tag_and_deploy services/tat
Updating main branch...
From github.com:Shared-Reality-Lab/IMAGE-server
 * branch              main       -> FETCH_HEAD
Already up to date.
Parsing GitHub workflow tag patterns...
Tagging services...
Explicit services provided: services/tat
Tagging service-tat: 0.6.8 -> 0.6.9 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-tat-0.6.9 -> service-tat-0.6.9
Done. Check workflows at:
  https://github.com/Shared-Reality-Lab/IMAGE-server/actions
Please note, to complete deployment to Pegasus, run imageup after the above workflows complete! :)
```

```
shahdy@unicorn:~/IMAGE-server$ ./scripts/tag_and_deploy 
shahdy@unicorn:/var/docker/image/testing/tag-and-deploy$ cat tag_and_deploy.2025.08.01-10.07.35
Updating main branch...
From github.com:Shared-Reality-Lab/IMAGE-server
 * branch              main       -> FETCH_HEAD
Already up to date.
Parsing GitHub workflow tag patterns...
Tagging components...
Tagging orchestrator: 0.4.4 -> 0.4.5 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           orchestrator-0.4.5 -> orchestrator-0.4.5
Tagging preprocessor-autour: 0.9.0 -> 0.9.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-autour-0.9.1 -> preprocessor-autour-0.9.1
No existing tags for preprocessor-celebrity-detector, skipping.
No existing tags for preprocessor-clothes-detector, skipping.
Tagging preprocessor-collage-detector: 0.6.0 -> 0.6.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-collage-detector-0.6.1 -> preprocessor-collage-detector-0.6.1
Tagging preprocessor-content-categoriser: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-content-categoriser-1.1.1 -> preprocessor-content-categoriser-1.1.1
Tagging preprocessor-depth-map-generator: 0.8.0 -> 0.8.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-depth-map-generator-0.8.1 -> preprocessor-depth-map-generator-0.8.1
Tagging preprocessor-graphic-caption: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-graphic-caption-1.1.1 -> preprocessor-graphic-caption-1.1.1
Tagging preprocessor-graphic-tagger: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-graphic-tagger-1.1.1 -> preprocessor-graphic-tagger-1.1.1
Tagging preprocessor-grouping: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-grouping-1.1.1 -> preprocessor-grouping-1.1.1
Skipping preprocessors/hello-preprocessor: no matching workflow tag
Tagging preprocessor-line-charts: 0.1.0 -> 0.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-line-charts-0.1.1 -> preprocessor-line-charts-0.1.1
Tagging preprocessor-mmsemantic-segmentation: 1.0.0 -> 1.0.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-mmsemantic-segmentation-1.0.1 -> preprocessor-mmsemantic-segmentation-1.0.1
Tagging preprocessor-multistage-diagram-segmentation: 0.4.0 -> 0.4.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-multistage-diagram-segmentation-0.4.1 -> preprocessor-multistage-diagram-segmentation-0.4.1
Tagging preprocessor-ner: 0.1.0 -> 0.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-ner-0.1.1 -> preprocessor-ner-0.1.1
Tagging preprocessor-nominatim: 1.0.0 -> 1.0.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-nominatim-1.0.1 -> preprocessor-nominatim-1.0.1
Tagging preprocessor-object-depth-calculator: 0.2.0 -> 0.2.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-object-depth-calculator-0.2.1 -> preprocessor-object-depth-calculator-0.2.1
Tagging preprocessor-object-detection-azure: 0.2.0 -> 0.2.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-object-detection-azure-0.2.1 -> preprocessor-object-detection-azure-0.2.1
Tagging preprocessor-ocr-clouds: 1.0.0 -> 1.0.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-ocr-clouds-1.0.1 -> preprocessor-ocr-clouds-1.0.1
Tagging preprocessor-openstreetmap: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-openstreetmap-1.1.1 -> preprocessor-openstreetmap-1.1.1
Tagging preprocessor-resize-graphic: 0.2.0 -> 0.2.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-resize-graphic-0.2.1 -> preprocessor-resize-graphic-0.2.1
Tagging preprocessor-sorting: 1.1.0 -> 1.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-sorting-1.1.1 -> preprocessor-sorting-1.1.1
Tagging preprocessor-text-followup: 0.2.0 -> 0.2.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-text-followup-0.2.1 -> preprocessor-text-followup-0.2.1
Tagging preprocessor-object-detection-yolo: 0.2.0 -> 0.2.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           preprocessor-object-detection-yolo-0.2.1 -> preprocessor-object-detection-yolo-0.2.1
Tagging handler-autour: 0.1.0 -> 0.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-autour-0.1.1 -> handler-autour-0.1.1
Skipping handlers/hello-handler: no matching workflow tag
Skipping handlers/hello-svg-handler: no matching workflow tag
Tagging handler-high-charts: 0.8.6 -> 0.8.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-high-charts-0.8.7 -> handler-high-charts-0.8.7
Tagging handler-map-tactile-svg: 0.3.0 -> 0.3.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-map-tactile-svg-0.3.1 -> handler-map-tactile-svg-0.3.1
Tagging handler-motd: 0.0.7 -> 0.0.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-motd-0.0.8 -> handler-motd-0.0.8
Tagging handler-multistage-diagram-tactile-svg: 0.2.6 -> 0.2.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-multistage-diagram-tactile-svg-0.2.7 -> handler-multistage-diagram-tactile-svg-0.2.7
Tagging handler-ocr: 0.0.7 -> 0.0.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-ocr-0.0.8 -> handler-ocr-0.0.8
Tagging handler-osm-streets: 0.0.7 -> 0.0.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-osm-streets-0.0.8 -> handler-osm-streets-0.0.8
Tagging handler-photo-audio: 0.1.6 -> 0.1.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-photo-audio-0.1.7 -> handler-photo-audio-0.1.7
Tagging handler-photo-audio-haptics: 0.1.6 -> 0.1.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-photo-audio-haptics-0.1.7 -> handler-photo-audio-haptics-0.1.7
Tagging handler-photo-tactile-svg: 0.3.0 -> 0.3.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-photo-tactile-svg-0.3.1 -> handler-photo-tactile-svg-0.3.1
Tagging handler-svg-depth-map: 0.8.6 -> 0.8.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-svg-depth-map-0.8.7 -> handler-svg-depth-map-0.8.7
Tagging handler-svg-od: 0.6.7 -> 0.6.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-svg-od-0.6.8 -> handler-svg-od-0.6.8
Tagging handler-svg-open-street-map: 0.0.2 -> 0.0.3 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-svg-open-street-map-0.0.3 -> handler-svg-open-street-map-0.0.3
Tagging handler-svg-semantic-seg: 0.7.7 -> 0.7.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-svg-semantic-seg-0.7.8 -> handler-svg-semantic-seg-0.7.8
Tagging handler-text-followup: 0.1.0 -> 0.1.1 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           handler-text-followup-0.1.1 -> handler-text-followup-0.1.1
Tagging service-espnet-tts: 0.2.6 -> 0.2.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-espnet-tts-0.2.7 -> service-espnet-tts-0.2.7
Tagging service-espnet-tts-fr: 0.2.6 -> 0.2.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-espnet-tts-fr-0.2.7 -> service-espnet-tts-fr-0.2.7
Tagging service-monarch-link-app: 0.2.6 -> 0.2.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-monarch-link-app-0.2.7 -> service-monarch-link-app-0.2.7
Tagging service-translation: 0.6.6 -> 0.6.7 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-translation-0.6.7 -> service-translation-0.6.7
Skipping services/supercollider-images: no matching workflow tag
Tagging service-tat: 0.6.7 -> 0.6.8 at HEAD
To github.com:Shared-Reality-Lab/IMAGE-server.git
 * [new tag]           service-tat-0.6.8 -> service-tat-0.6.8
Done. Check workflows at:
  https://github.com/Shared-Reality-Lab/IMAGE-server/actions
Please note, to complete deployment to Pegasus, run imageup after the above workflows complete! :)


```

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [X] I described the changes made and how these address the issue.
- [X] I described how I tested these changes.

## Coding/Commit Requirements

* [X] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [X] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [X] I have not added a new component in this PR.
