### PR TITLE
Return 204 if no stages found in multistage-diagram-segmentation

### DIFF
--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -702,7 +702,7 @@ def process_diagram():
             if isinstance(stage, dict) and "label" in stage
             ]
         if not stages or len(stages) == 0:
-            logging.warning(
+            logging.info(
                 "No stage labels found. Cannot request bounding boxes."
                 )
             return jsonify(

--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -701,14 +701,13 @@ def process_diagram():
             for stage in base_json.get("stages", [])
             if isinstance(stage, dict) and "label" in stage
             ]
-        if not stages:
+        if not stages or len(stages) == 0:
             logging.warning(
                 "No stage labels found. Cannot request bounding boxes."
                 )
-            aggregated_contour_data = {}
-            final_data_json = update_json_with_contours(
-                base_json, aggregated_contour_data
-                )
+            return jsonify(
+                {"error": "No valid stage labels found in the diagram"}
+                ), 204
 
         else:
             logging.pii(f"Identified stages: {stages}")


### PR DESCRIPTION
Fixes #1124 

If the `multistage-diagram-segmentation` does not find any stages, the preprocessor will return the code `204` instead of returning an empty list of stages.

Tested on Unicorn using graphics that do not contain stages.
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
