### PR TITLE
Update LLM engine (Ollama -> vLLM) and request library (requests -> OpenAI)

### DIFF
--- a/config/logging_utils.py
+++ b/config/logging_utils.py
@@ -34,3 +34,13 @@ def configure_logging():
         logging.getLogger().setLevel(PII_LOG_LEVEL)  # Lower log level to PII
     else:
         logging.info("Environment Pegasus: PII logging is disabled.")
+
+    # Suppress verbose logging from OpenAI and its dependencies
+    # Prevents logging of request bodies which contain base64 images and PII
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+    # Optional: Add info about suppressed loggers
+    logging.debug("Suppressed verbose logging for OpenAI client libraries")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,7 @@ services:
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
 
   depth-map-generator:
-    profiles: [production, test, default]
+    profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-preprocessor-depth-map-generator:${REGISTRY_TAG}
     restart: "no"
     deploy:
@@ -392,7 +392,7 @@ services:
       - WARMUP_ENABLED=true
 
   svg-depth-map:
-    profiles: [production, test, default]
+    profiles: [test, default]
     image: ghcr.io/shared-reality-lab/image-handler-svg-depth-map:${REGISTRY_TAG}
     restart: "no"
     labels:

--- a/preprocessors/content-categoriser/requirements.txt
+++ b/preprocessors/content-categoriser/requirements.txt
@@ -4,6 +4,4 @@ jsonschema==4.23.0
 Werkzeug==3.1.0
 gunicorn==23.0.0
 requests==2.32.3
-
-
-
+openai==1.98.0

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -88,10 +88,6 @@ def categorise():
     source = content["graphic"]
     graphic_b64 = source.split(",")[1]
 
-    # vllm_base_url = f"{os.environ['OLLAMA_URL']}"
-    # api_key = os.environ['OLLAMA_API_KEY']
-    # vllm_model = os.environ['OLLAMA_MODEL']
-
     # prepare vllm request
     vllm_base_url = os.environ['VLLM_URL']
     api_key = os.environ['VLLM_API_KEY']

--- a/preprocessors/graphic-caption/caption.py
+++ b/preprocessors/graphic-caption/caption.py
@@ -125,7 +125,7 @@ def categorise():
                         {
                             "type": "image_url",
                             "image_url": {
-                                "url": f"data:image/jpeg;base64,{graphic_b64}"
+                                "url": f"data:image/png;base64,{graphic_b64}"
                             }
                         }
                     ]

--- a/preprocessors/graphic-caption/requirements.txt
+++ b/preprocessors/graphic-caption/requirements.txt
@@ -4,5 +4,6 @@ jsonschema==4.23.0
 Werkzeug==3.1.3
 gunicorn==23.0.0
 requests==2.32.3
+openai==1.98.0
 
 

--- a/preprocessors/text-followup/requirements.txt
+++ b/preprocessors/text-followup/requirements.txt
@@ -4,3 +4,4 @@ jsonschema==3.2.0
 Werkzeug==3.1.0
 gunicorn==23.0.0
 requests==2.32.3
+openai==1.98.0

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -24,6 +24,7 @@ import os
 import html
 from datetime import datetime
 from config.logging_utils import configure_logging
+from openai import OpenAI
 
 app = Flask(__name__)
 
@@ -153,8 +154,8 @@ def followup():
               Here is an example of the output JSON in the format you
               are REQUIRED to follow:
               {
-                "response_brief": "One sentence response to the user request.",
-                "response_full": "Further details. Maximum three sentences."
+              "response_brief": "One sentence response to the user request.",
+              "response_full": "Further details. Maximum three sentences."
               }
               Note that the first character of output MUST be "{".
               Remove all whitespace before and after the JSON.
@@ -163,37 +164,51 @@ def followup():
     general_prompt = os.getenv('TEXT_FOLLOWUP_PROMPT_OVERRIDE', general_prompt)
     user_prompt = content["followup"]["query"]
 
-    # prepare ollama request
-    api_url = f"{os.environ['OLLAMA_URL']}/chat"
-    api_key = os.environ['OLLAMA_API_KEY']
-    ollama_model = os.environ['OLLAMA_MODEL']
+    # prepare vllm request
+    vllm_base_url = os.environ['VLLM_URL']
+    api_key = os.environ['VLLM_API_KEY']
+    vllm_model = os.environ['VLLM_MODEL']
 
-    logging.debug("OLLAMA_URL " + api_url)
+    logging.debug("VLLM_URL " + vllm_base_url)
+    logging.debug("VLLM_MODEL " + vllm_model)
     if api_key.startswith("sk-"):
-        logging.pii("OLLAMA_API_KEY looks properly formatted: sk-[redacted]")
+        logging.pii("VLLM_API_KEY looks properly formatted: sk-[redacted]")
     else:
-        logging.warning("OLLAMA_API_KEY does not start with sk-")
+        logging.warning("VLLM_API_KEY does not start with sk-")
 
-    # Create messages list for chat endpoint instead of single prompt
-    system_message = {
-        "role": "system",
-        "content": general_prompt
-    }
+    # Initialize OpenAI client with custom base URL for vllm
+    client = OpenAI(
+        api_key=api_key,
+        base_url=vllm_base_url
+    )
 
-    user_message = {
-        "role": "user",
-        "content": user_prompt,
-    }
+    system_message = {"role": "system", "content": general_prompt}
 
     # Retrieve existing conversation history or create new one
     if uuid_exists:
-        # Add new user message
+        # For follow-up messages, add the new user prompt
+        user_message = {
+            "role": "user",
+            "content": user_prompt
+        }
         conversation_history[request_uuid]['messages'].append(user_message)
         conversation_history[request_uuid]['last_updated'] = timestamp
     else:
-        # Attach the image to the first request
-        user_message["images"] = [graphic_b64]
-        # Start a new conversation with system and user messages
+        # For the first message, create a new history entry
+        # include the system prompt, the user's text, and the image
+        user_message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{graphic_b64}"
+                    }
+                }
+            ]
+        }
+
         conversation_history[request_uuid] = {
             'messages': [system_message, user_message],
             'last_updated': timestamp
@@ -216,55 +231,65 @@ def followup():
     for msg in messages:
         # Create a copy to avoid modifying the original
         log_msg = msg.copy()
-        if 'images' in log_msg:
-            # Replace image content with placeholder or truncate it
-            log_msg['images'] = [
-                    f"[BASE64_IMAGE:{len(img)} bytes]"
-                    for img in log_msg['images']
-                ]
+        if isinstance(msg.get('content'), list):
+            # Handle multi-part content (text + image)
+            log_content = []
+            for part in msg['content']:
+                if part['type'] == 'image_url':
+                    log_content.append({
+                        'type': 'image_url',
+                        'image_url': {'url': '[BASE64_IMAGE]'}
+                    })
+                else:
+                    log_content.append(part)
+            log_msg['content'] = log_content
         log_friendly_messages.append(log_msg)
+
     logging.pii(
         f"Message history: {json.dumps(log_friendly_messages, indent=2)}"
         )
     logging.debug(f"User followup prompt: {general_prompt} [redacted]")
 
     # Create request data for chat endpoint
-    request_data = {
-        "model": ollama_model,
-        "messages": messages,
-        "stream": False,
-        "temperature": 0.0,
-        "format": {
-            "type": "object",
-            "properties": {
-                "response_brief": {"type": "string"},
-                "response_full": {"type": "string"},
-            },
-            "required": ["response_brief", "response_full"],
-        },
-        "keep_alive": -1,  # keep model loaded in memory indefinitely
-    }
+    try:
+        logging.debug("Posting request to vllm model " + vllm_model)
 
-    logging.debug("serializing json from request_data dictionary")
-    request_data_json = json.dumps(request_data)
+        from pydantic import BaseModel, Field
 
-    request_headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}"
-    }
+        class ResponseModel(BaseModel):
+            response_brief: str = Field(
+                ...,
+                description="One sentence response to the user request."
+            )
+            response_full: str = Field(
+                ...,
+                description="Further details. Maximum three sentences."
+            )
+        json_schema = ResponseModel.model_json_schema()
 
-    logging.debug("Posting request to ollama model " + ollama_model)
-    response = requests.post(api_url, headers=request_headers,
-                             data=request_data_json)
-    logging.debug("ollama request response code: " + str(response.status_code))
+        # Make the request using OpenAI client
+        response = client.chat.completions.create(
+            model=vllm_model,
+            messages=messages,
+            temperature=0.0,
+            stream=False,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "response-format",
+                    "schema": json_schema
+                },
+            }
+        )
 
-    if response.status_code == 200:
-        ollama_error_msg = None
+        # The OpenAI library handles status codes internally
+        # A successful response means status code was 200
+        logging.debug("vllm request response code: 200")
+
         try:
-            response_json = json.loads(response.text)
-            # strip() at end since llama often puts a newline before json
-            response_text = response_json['message']['content'].strip()
-            logging.pii("raw ollama response: " + response_text)
+            # Get the response content
+            response_text = response.choices[0].message.content.strip()
+            logging.pii("raw vllm response: " + response_text)
             followup_response_json = json.loads(response_text)
 
             # Format assistant response for history
@@ -287,21 +312,20 @@ def followup():
                 )
 
         except json.JSONDecodeError:
-            ollama_error_msg = "raw response does not look like json"
-        except KeyError:
-            ollama_error_msg = "no response tag found in returned json"
-        except TypeError:  # have seen this when we just get a string back
-            # TODO: investigate what is actually happening here!
-            ollama_error_msg = "unknown error decoding json. investigate!"
-        finally:
-            if ollama_error_msg is not None:
-                logging.error(ollama_error_msg + " returning 204")
-                return jsonify("Invalid LLM results"), 204
-    else:
-        logging.error(f"Error {response.status_code}: \
-                      [response text redacted]")
-        return jsonify("Invalid response from ollama"), 204
-    # check if ollama returned valid json that follows schema
+            logging.error("raw response does not look like json")
+            return jsonify("Invalid LLM results"), 204
+        except (KeyError, AttributeError):
+            logging.error("no response content found in returned object") 
+            return jsonify("Invalid LLM results"), 204
+        except TypeError:
+            logging.error("unknown error decoding json, returning 204")
+            return jsonify("Invalid LLM results"), 204
+
+    except Exception as e:
+        logging.error(f"Error calling vllm: {str(e)}")
+        return jsonify("Invalid response from vllm"), 204
+
+    # check if LLM returned valid json that follows schema
     try:
         validator = jsonschema.Draft7Validator(data_schema)
         validator.validate(followup_response_json)

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -446,7 +446,7 @@ def warmup():
             timeout=60.0
         )
 
-        logging.debug("Posting request to vllm model " + llm_model)
+        logging.debug("Posting request to LLM model: " + llm_model)
 
         # Make the request using OpenAI client
         client.chat.completions.create(

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from config.logging_utils import configure_logging
 from openai import OpenAI
 from pydantic import BaseModel, Field
+from typing import Optional
 
 
 app = Flask(__name__)
@@ -48,9 +49,10 @@ class ResponseModel(BaseModel):
         ...,
         description="One sentence response to the user request."
     )
-    response_full: str = Field(
-        ...,
-        description="Further details. Maximum three sentences."
+    response_full: Optional[str] = Field(
+        None,
+        description="Further details. Maximum three sentences. "
+        "This field can be omitted entirely."
     )
 
 

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -15,7 +15,6 @@
 # <https://github.com/Shared-Reality-Lab/IMAGE-server/blob/main/LICENSE>.
 
 from flask import Flask, request, jsonify
-import requests
 import json
 import time
 import jsonschema
@@ -318,7 +317,7 @@ def followup():
             logging.error("raw response does not look like json")
             return jsonify("Invalid LLM results"), 204
         except (KeyError, AttributeError):
-            logging.error("no response content found in returned object") 
+            logging.error("no response content found in returned object")
             return jsonify("Invalid LLM results"), 204
         except TypeError:
             logging.error("unknown error decoding json, returning 204")
@@ -433,32 +432,38 @@ def warmup():
     """
     Trigger a warmup call to load the Ollama LLM into memory.
     This avoids first-request latency by sending a dummy request.
+    vLLM keeps the model in memory after the container startup.
     """
     try:
-        # construct the target Ollama endpoint for generate
-        api_url = f"{os.environ['OLLAMA_URL']}/generate"
+        llm_base_url = os.environ['LLM_URL']
+        api_key = os.environ['LLM_API_KEY']
+        llm_model = os.environ['LLM_MODEL']
 
-        # authorization headers with API key
-        headers = {
-            "Authorization": f"Bearer {os.environ['OLLAMA_API_KEY']}",
-            "Content-Type": "application/json"
-        }
+        # Initialize OpenAI client with custom base URL for vllm
+        client = OpenAI(
+            api_key=api_key,
+            base_url=llm_base_url,
+            timeout=60.0
+        )
 
-        # prepare the warmup request data using the configured model
-        data = {
-            "model": os.environ["OLLAMA_MODEL"],
-            "prompt": "ping",
-            "stream": False,
-            "keep_alive": -1  # instruct Ollama to keep the model in memory
-        }
+        logging.debug("Posting request to vllm model " + llm_model)
+
+        # Make the request using OpenAI client
+        client.chat.completions.create(
+            model=llm_model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "ping"
+                }
+            ],
+            temperature=0.0,
+            stream=False
+        )
 
         logging.info("[WARMUP] Warmup endpoint triggered.")
-        logging.pii(f"[WARMUP] Posting to {api_url} with model \
-                    {data['model']}")
-
-        # send warmup request (with timeout)
-        r = requests.post(api_url, headers=headers, json=data, timeout=60)
-        r.raise_for_status()
+        logging.pii(f"[WARMUP] Posting to {llm_base_url} with model \
+                    {llm_model}")
 
         return jsonify({"status": "warmed"}), 200
 


### PR DESCRIPTION
Resolves #1119 

We are moving from Ollama to vLLM as our LLM/VLM engine.
This requires changes in routes and libraries.

Major changes:
- using the `OpenAI` library instead of the `requests` library to make requests to the model
- changing routes: now we don't need to use `/chat/completions` or `/generate` routes because they will be in the request (i.e. `client.chat.completions.create`)
- changing variable names, comments, and info/debug messages to be generalized (Ollama -> LLM)
- adding Pydantic models for JSON schemas in preprocessors producing structured outputs
- removing the unused `depth-map-generator` preprocessor from production to free up GPU memory
- warmups are technically not needed anymore (vLLM keeps the model in memory from the moment of the container startup), but I refactored and kept them for consistency
- adding verbose logging suppression for the OpenAI-related libraries due to debug messages containing PII

Tested on Pegasus using extension, logging, and `text-followup` queries.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.