### PR TITLE
Move non-LLM services to Titan XP

### DIFF
--- a/test-docker-compose.yml
+++ b/test-docker-compose.yml
@@ -68,7 +68,7 @@ services:
         reservations:
           devices:
           - driver: nvidia
-            device_ids: ['0']
+            device_ids: ['1']
             capabilities: ["gpu", "utility", "compute"]
 
   espnet-tts:
@@ -77,7 +77,7 @@ services:
         reservations:
             devices:
             - driver: nvidia
-              device_ids: ['0']
+              device_ids: ['1']
               capabilities: ["gpu", "utility", "compute"]
 
   espnet-tts-fr:
@@ -86,7 +86,7 @@ services:
         reservations:
             devices:
             - driver: nvidia
-              device_ids: ['0']
+              device_ids: ['1']
               capabilities: ["gpu", "utility", "compute"]
 
   multilang-support:
@@ -95,7 +95,7 @@ services:
         reservations:
             devices:
             - driver: nvidia
-              device_ids: ['0']
+              device_ids: ['1']
               capabilities: ["gpu", "utility", "compute"]
 
   monarch-link-app:


### PR DESCRIPTION
This change moves non-LLM services to the Titan XP GPU on Unicorn.
Reasoning: vLLM can only run on the 1660 Ti GPU (GPU 0 on Unicorn), and we want to keep this graphics card fully available for vLLM testing with as much free memory as possible.

Tested on Unicorn.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
