### PR TITLE
Update PIL version for AVIF support

### DIFF
--- a/preprocessors/resize-graphic/requirements.txt
+++ b/preprocessors/resize-graphic/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.1.0
 requests==2.32.3
 jsonschema==4.23.0
 gunicorn==23.0.0
-pillow==11.1.0
+pillow==11.3.0


### PR DESCRIPTION
Resolves #679

PIL 11.3.0 natively [supports](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#avif) AVIF graphics. Updating the version in the `requirements.txt` ensures the `resize-graphic` preprocessor can resize/reformat AVIF files.

Tested on Unicorn via override.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
