### PR TITLE
check GPU health at the *host* level, removing this outside of semseg

### DIFF
--- a/preprocessors/mmsemseg/Dockerfile
+++ b/preprocessors/mmsemseg/Dockerfile
@@ -53,6 +53,6 @@ ENV FLASK_APP=segment.py
 USER python
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=5 \
-  CMD curl -f http://localhost:5000/health && curl -f http://localhost:5000/health/gpu || exit 1
+  CMD curl -f http://localhost:5000/health || exit 1
 
 CMD [ "gunicorn", "segment:app", "-b", "0.0.0.0:5000", "--capture-output", "--log-level=debug" ]

--- a/preprocessors/mmsemseg/segment.py
+++ b/preprocessors/mmsemseg/segment.py
@@ -263,66 +263,6 @@ def health():
     }), 200
 
 
-@app.route("/health/gpu", methods=["GET"])
-def gpu_driver_health_check():
-    """
-    Enhanced health check:
-    - Verifies CUDA & NVIDIA drivers are working
-    - Detects if the loaded NVIDIA driver matches `nvidia-smi`
-    - Ensures the container is using the correct GPU runtime
-    """
-
-    # Check if CUDA is available
-    if not torch.cuda.is_available():
-        return jsonify({
-            "status": "unhealthy",
-            "message": "CUDA not available inside the container",
-            "recommendation": "Check if the container is running with GPU \
-                access (--gpus all)"
-        }), 500
-
-    try:
-        # Get installed NVIDIA driver version from nvidia-smi
-        nvidia_smi_version = subprocess.check_output(
-            [
-                "nvidia-smi",
-                "--query-gpu=driver_version",
-                "--format=csv,noheader"
-            ],
-            text=True
-        ).strip().split("\n")[0]
-
-        # Get loaded driver version from /proc/driver/nvidia/version
-        loaded_driver_version = subprocess.check_output(
-            ["cat", "/proc/driver/nvidia/version"], text=True
-        ).split("\n")[0]
-
-        # Ensure they match
-        if nvidia_smi_version not in loaded_driver_version:
-            return jsonify({
-                "status": "unhealthy",
-                "message": "NVIDIA driver mismatch detected",
-                "nvidia_smi_version": nvidia_smi_version,
-                "loaded_driver_version": loaded_driver_version,
-                "recommendation": "Reboot the system to ensure the correct \
-                    driver is loaded?"
-            }), 500
-
-        return jsonify({
-            "status": "healthy",
-            "message": "NVIDIA drivers and CUDA are working correctly",
-            "nvidia_smi_version": nvidia_smi_version,
-            "loaded_driver_version": loaded_driver_version
-        }), 200
-
-    except Exception as e:
-        return jsonify({
-            "status": "unhealthy",
-            "message": f"NVIDIA driver check failed: {str(e)}",
-            "recommendation": "Check driver installation and restart system"
-        }), 500
-
-
 @app.route("/warmup", methods=["GET"])
 def warmup():
     """

--- a/preprocessors/mmsemseg/segment.py
+++ b/preprocessors/mmsemseg/segment.py
@@ -35,7 +35,6 @@ from time import time
 import logging
 from config.logging_utils import configure_logging
 from datetime import datetime
-import subprocess
 
 configure_logging()
 # configuration and checkpoint files

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -32,6 +32,44 @@ echo "ALL RUNNING CONTAINERS ON $SERVER_NAME: $RUNNING_CONTAINERS" >> "$LOG_FILE
 
 MESSAGES=""
 
+# --- HOST GPU HEALTH (NVML + driver version mismatch) ------------------------
+# We check GPU health at the *host* level (not inside containers) to avoid
+# container-specific false positives. Any issues found are appended to MESSAGES
+# and logged to $LOG_FILE; container polling continues as usual.
+
+# 1) NVML / nvidia-smi availability
+if ! nvidia-smi >/dev/null 2>&1; then
+  MSG=":warning: Host *$SERVER_NAME* GPU *unhealthy*: NVML unavailable (nvidia-smi failed)."
+  MESSAGES+="$MSG"$'\n'
+  echo "$(date) - $MSG" >> "$LOG_FILE"
+else
+  # 2) Compare numeric driver versions from nvidia-smi vs kernel module
+  SMI_VER="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | sort -u | head -n1)"
+  PROC_VER="$(grep -Po '\d+\.\d+\.\d+' /proc/driver/nvidia/version 2>/dev/null | head -n1)"
+
+  if [ -z "$SMI_VER" ] || [ -z "$PROC_VER" ]; then
+    MSG=":warning: Host *$SERVER_NAME* GPU *warning*: could not read driver versions (smi='${SMI_VER:-NA}', proc='${PROC_VER:-NA}')."
+    MESSAGES+="$MSG"$'\n'
+    echo "$(date) - $MSG" >> "$LOG_FILE"
+  elif [ "$SMI_VER" != "$PROC_VER" ]; then
+    # (Optional) also record CUDA version from the nvidia-smi header
+    SMI_HEAD="$(nvidia-smi | head -n1 2>/dev/null)"
+    CUDA_VER="$(echo "$SMI_HEAD" | sed -n 's/.*CUDA Version: *\([0-9.]\+\).*/\1/p')"
+
+    MSG=":warning: Host *$SERVER_NAME* – NVIDIA driver *mismatch* detected:
+• nvidia-smi: ${SMI_VER}
+• kernel:     ${PROC_VER}"
+    if [ -n "$CUDA_VER" ]; then
+      MSG="$MSG"$'\n'"• CUDA:       ${CUDA_VER}"
+    fi
+    MSG="$MSG"$'\n'"Consider scheduling a reboot to reconcile."
+
+    MESSAGES+="$MSG"$'\n'
+    echo "$(date) - NVIDIA driver mismatch on $SERVER_NAME (smi=${SMI_VER}, kernel=${PROC_VER}${CUDA_VER:+, cuda=${CUDA_VER}})" >> "$LOG_FILE"
+  fi
+fi
+# -----------------------------------------------------------------------------
+
 # Loop through the list of all containers on the "image" network
 for EXPECTED_CONTAINER in $ALL_IMAGE_CONTAINERS; do
   FOUND=0
@@ -80,3 +118,4 @@ if [ -n "$MESSAGES" ]; then
 else
   echo "$(date) - No issues detected. No notifications sent." >> "$LOG_FILE"
 fi
+

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -37,23 +37,29 @@ MESSAGES=""
 # container-specific false positives. Any issues found are appended to MESSAGES
 # and logged to $LOG_FILE; container polling continues as usual.
 
+SMI_BIN="$(command -v nvidia-smi || true)"
+TIMEOUT_SEC=5
+
 # 1) NVML / nvidia-smi availability
-if ! nvidia-smi >/dev/null 2>&1; then
+if [ -z "$SMI_BIN" ] || ! timeout "${TIMEOUT_SEC}s" "$SMI_BIN" >/dev/null 2>&1; then
   MSG=":warning: Host *$SERVER_NAME* GPU *unhealthy*: NVML unavailable (nvidia-smi failed)."
   MESSAGES+="$MSG"$'\n'
   echo "$(date) - $MSG" >> "$LOG_FILE"
 else
   # 2) Compare numeric driver versions from nvidia-smi vs kernel module
-  SMI_VER="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | sort -u | head -n1)"
-  PROC_VER="$(grep -Po '\d+\.\d+\.\d+' /proc/driver/nvidia/version 2>/dev/null | head -n1)"
+  SMI_VER="$(timeout "${TIMEOUT_SEC}s" "$SMI_BIN" --query-gpu=driver_version --format=csv,noheader 2>/dev/null \
+            | awk 'NF' | sort -u | head -n1)"
+
+  # parse kernel module's version from /proc
+  PROC_VER="$(sed -nE 's/.*Kernel Module[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' /proc/driver/nvidia/version 2>/dev/null | head -n1)"
 
   if [ -z "$SMI_VER" ] || [ -z "$PROC_VER" ]; then
     MSG=":warning: Host *$SERVER_NAME* GPU *warning*: could not read driver versions (smi='${SMI_VER:-NA}', proc='${PROC_VER:-NA}')."
     MESSAGES+="$MSG"$'\n'
     echo "$(date) - $MSG" >> "$LOG_FILE"
   elif [ "$SMI_VER" != "$PROC_VER" ]; then
-    # (Optional) also record CUDA version from the nvidia-smi header
-    SMI_HEAD="$(nvidia-smi | head -n1 2>/dev/null)"
+    # Capture the CUDA API version (from nvidia-smi header).
+    SMI_HEAD="$(timeout "${TIMEOUT_SEC}s" "$SMI_BIN" | head -n1 2>/dev/null)"
     CUDA_VER="$(echo "$SMI_HEAD" | sed -n 's/.*CUDA Version: *\([0-9.]\+\).*/\1/p')"
 
     MSG=":warning: Host *$SERVER_NAME* – NVIDIA driver *mismatch* detected:

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -33,9 +33,9 @@ echo "ALL RUNNING CONTAINERS ON $SERVER_NAME: $RUNNING_CONTAINERS" >> "$LOG_FILE
 MESSAGES=""
 
 # --- HOST GPU HEALTH (NVML + driver version mismatch) ------------------------
-# We check GPU health at the *host* level (not inside containers) to avoid
-# container-specific false positives. Any issues found are appended to MESSAGES
-# and logged to $LOG_FILE; container polling continues as usual.
+# Host-side GPU check:
+# - run nvidia-smi (NVML) with a short timeout
+# - compare driver version from nvidia-smi vs kernel module
 
 SMI_BIN="$(command -v nvidia-smi || true)"
 TIMEOUT_SEC=5
@@ -58,7 +58,7 @@ else
     MESSAGES+="$MSG"$'\n'
     echo "$(date) - $MSG" >> "$LOG_FILE"
   elif [ "$SMI_VER" != "$PROC_VER" ]; then
-    # Capture the CUDA API version (from nvidia-smi header).
+    # grab CUDA version from the nvidia-smi header
     SMI_HEAD="$(timeout "${TIMEOUT_SEC}s" "$SMI_BIN" | head -n1 2>/dev/null)"
     CUDA_VER="$(echo "$SMI_HEAD" | sed -n 's/.*CUDA Version: *\([0-9.]\+\).*/\1/p')"
 
@@ -72,9 +72,13 @@ else
 
     MESSAGES+="$MSG"$'\n'
     echo "$(date) - NVIDIA driver mismatch on $SERVER_NAME (smi=${SMI_VER}, kernel=${PROC_VER}${CUDA_VER:+, cuda=${CUDA_VER}})" >> "$LOG_FILE"
+  else
+    # versions match — log a simple OK line (no Slack)
+    SMI_HEAD="$(timeout "${TIMEOUT_SEC}s" "$SMI_BIN" | head -n1 2>/dev/null)"
+    CUDA_VER="$(echo "$SMI_HEAD" | sed -n 's/.*CUDA Version: *\([0-9.]\+\).*/\1/p')"
+    echo "$(date) - Host GPU healthy (driver=${SMI_VER}${CUDA_VER:+, cuda=${CUDA_VER}})." >> "$LOG_FILE"
   fi
 fi
-# -----------------------------------------------------------------------------
 
 # Loop through the list of all containers on the "image" network
 for EXPECTED_CONTAINER in $ALL_IMAGE_CONTAINERS; do


### PR DESCRIPTION
Currently, the semseg /health/gpu endpoint ran host checks from inside the container:
nvidia-smi (NVML)
/proc/driver/nvidia/version 

which was designed to compare the strings and return 500 on a mismatch or NVML error.
In practice, we found that containers can lose access to NVML/CUDA (or have it partially mounted) even when the host is fine. 
inside the container nvidia-smi -> “Failed to initialize NVML” and torch.cuda.is_available() -> False.

The scope was incorrect, since this is a host concern. Doing it inside the container makes results dependent on other variables besides the real driver state. 

I've updated the healthcheck script to include identical GPU checks to the host. if there’s a problem, it logs the precise reason and appends one host-level line to Slack.

This should fix the spam/false-positive pain; we parse numeric versions and just log them, we see exactly which versions caused the mismatch. 


Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [X] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
