### PR TITLE
Unlock multistage-diagram-segmentation

### DIFF
--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -31,10 +31,6 @@ from utils.llm import (
     )
 from utils.segmentation import SAMClient
 from utils.validation import Validator
-# from utils.llm.response_schemas import (
-#     STAGE_RESPONSE_SCHEMA,
-#     BBOX_RESPONSE_SCHEMA
-#     )
 import json
 
 configure_logging()

--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -84,14 +84,18 @@ def process_diagram():
     if "graphic" not in content:
         logging.info("No graphic content. Skipping...")
         return jsonify({"error": "No graphic content"}), 204
-    if not any(
-        content["URL"].startswith(origin) for origin in ALLOWED_ORIGINS
-            ):
 
-        logging.info(
-            "Request URL does not match expected endpoint. Skipping."
-            )
-        return jsonify({"error": "Invalid request URL"}), 403
+    # Uncomment if you are planning to use cloud-based models
+    # and don't have control over data residency and PII handling.
+
+    # if not any(
+    #     content["URL"].startswith(origin) for origin in ALLOWED_ORIGINS
+    #         ):
+
+    #     logging.info(
+    #         "Request URL does not match expected endpoint. Skipping."
+    #         )
+    #     return jsonify({"error": "Invalid request URL"}), 403
 
     # 1. Validate Incoming Request
     try:


### PR DESCRIPTION
Since we're running Qwen locally, we are in full control of PII. Now, we can unlock the multistage-diagram preprocessor for all origins.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
