### PR TITLE
Fix content-categoriser output JSON structure

### DIFF
--- a/preprocessors/content-categoriser/categoriser.py
+++ b/preprocessors/content-categoriser/categoriser.py
@@ -88,11 +88,9 @@ def categorise():
         ), 500
 
     logging.pii(f"Graphic category JSON: {graphic_category}")
-    # create data json and verify the content-categoriser schema is respected
-    graphic_category_json = {"category": graphic_category}
 
     # data schema validation
-    ok, _ = validator.check_data(graphic_category_json)
+    ok, _ = validator.check_data(graphic_category)
     if not ok:
         return jsonify("Invalid Preprocessor JSON format"), 500
 
@@ -101,7 +99,7 @@ def categorise():
         "request_uuid": request_uuid,
         "timestamp": int(timestamp),
         "name": PREPROCESSOR_NAME,
-        "data": graphic_category_json
+        "data": graphic_category
     }
 
     # response envelope validation


### PR DESCRIPTION
This PR ensures that the output of the `content-categoriser` preprocessor is in accordance with the schema.
After refactoring LLM-based components, LLM produces the output formatted as `{'category': '_category_name_'}`.

I mistakenly left in the code the additional structure that was assigning this key-value pair again, making the output look like `'{category: '{'category': '_category_name_'}}` causing the preprocessor to fail the validation.

Tested on Unicorn: now the output is validated successfully.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
