### PR TITLE
Add check for empty label

### DIFF
--- a/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
+++ b/preprocessors/multistage-diagram-segmentation/multistage-diagram-segmentation.py
@@ -129,12 +129,13 @@ def process_diagram():
             for stage in base_json.get("stages", [])
             if isinstance(stage, dict) and "label" in stage
             ]
-        if not stages or len(stages) == 0:
+        if not stages or len(stages) == 0 or any(s == "" for s in stages):
             logging.info(
-                "No stage labels found. Cannot request bounding boxes."
+                "Some or all stage labels not found. "
+                "Cannot request bounding boxes."
                 )
             return jsonify(
-                {"error": "No valid stage labels found in the diagram"}
+                {"error": "Valid stage labels not found in the diagram"}
                 ), 204
 
         else:


### PR DESCRIPTION
Resolves #1143.

If **any** of the stage labels is empty, the preprocessor will return `204`.
This prevents running most of the `multistage-diagram-segmentation` steps on non-diagram graphics and incomplete diagrams.

Tested on Unicorn with non-diagram graphics.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
