### PR TITLE
update categorizer schema

### DIFF
--- a/preprocessors/content-categoriser.schema.json
+++ b/preprocessors/content-categoriser.schema.json
@@ -2,10 +2,43 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://image.a11y.mcgill.ca/preprocessors/content-categoriser.schema.json",
     "type": "object",
-    "title": "Content Categoriser",
-    "description": "Classifier for categorising the content into graphic, text, chart or other. Accessed as 'ca.mcgill.a11y.image.preprocessor.contentCategoriser'.",
+    "title": "Graphic Categories",
+    "description": "Boolean tags for categorizing graphics and images",
     "properties": {
-        "category": { "enum": ["chart", "photograph", "other","text"] }
-    },
-    "required": [ "category"]
+        "categories": {
+            "type": "object",
+            "description": "Object containing boolean flags for different image categories",
+            "properties": {
+                "photo": {
+                    "type": "boolean",
+                    "description": "True if the graphic is a photograph"
+                },
+                "diagram": {
+                    "type": "boolean",
+                    "description": "True if the graphic contains diagrams or technical illustrations"
+                },
+                "multistage_diagram": {
+                    "type": "boolean",
+                    "description": "True if the graphic is a flow diagram with stages and links between them"
+                },
+                "contains_text": {
+                    "type": "boolean",
+                    "description": "True if the graphic contains readable text"
+                },
+                "collage": {
+                    "type": "boolean",
+                    "description": "True if the graphic is a collage or composite of multiple images"
+                },
+                "chart_or_graph": {
+                    "type": "boolean",
+                    "description": "True if the graphic contains charts, graphs, or data visualizations"
+                },
+                "illustration": {
+                    "type": "boolean",
+                    "description": "True if the graphic is a drawing, painting, or artistic illustration"
+                }
+            },
+            "additionalProperties": {"type": "boolean"}
+        }
+    }
 }


### PR DESCRIPTION
One of two PRs to complete #1015
As discussed, with @JRegimbal and @jeffbl, the `content-categoriser` schema now contains a set of boolean tags.

Tested on Unicorn by passing the updated schema to the `content-categoriser` preprocessor: the graphics are parsed correctly, and the output is successfully validated.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
