### PR TITLE
Reduce MAX_GRAPHIC_DIMENSION to 1200

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       ca.mcgill.a11y.image.required_dependencies: ""
       ca.mcgill.a11y.image.optional_dependencies: ""
     environment:
-      - MAX_GRAPHIC_DIMENSION=2048
+      - MAX_GRAPHIC_DIMENSION=1200
       - PII_LOGGING_ENABLED=${PII_LOGGING_ENABLED}
 
   espnet-tts:


### PR DESCRIPTION

This pull request makes a minor configuration change to the `docker-compose.yml` file, specifically adjusting the maximum allowed graphic dimension for a service.

* Reduced the value of the `MAX_GRAPHIC_DIMENSION` environment variable from 2048 to 1200 for one of the services in `docker-compose.yml`.
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [ ] I referenced the issue addressed in this PR.
- [ ] I described the changes made and how these address the issue.
- [ ] I described how I tested these changes.

## Coding/Commit Requirements

* [ ] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [ ] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [ ] I have not added a new component in this PR.
