### PR TITLE
Fix dimension rounding error

### DIFF
--- a/preprocessors/object-detection-llm/object-detection-llm.py
+++ b/preprocessors/object-detection-llm/object-detection-llm.py
@@ -61,10 +61,10 @@ def normalize_bbox(bbox, width, height):
     """
     x1, y1, x2, y2 = bbox
     return [
-        x1 / width,
-        y1 / height,
-        x2 / width,
-        y2 / height
+        max(0.0, min(x1 / width, 1.0)),
+        max(0.0, min(y1 / height, 1.0)),
+        max(0.0, min(x2 / width, 1.0)),
+        max(0.0, min(y2 / height, 1.0))
     ]
 
 


### PR DESCRIPTION
Provide a fallback in case normalized object coordinates are outside of the [0, 1] range due to the rounding error.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
