### PR TITLE
Update multistage-diagram-segmentation preprocessor

### DIFF
--- a/utils/llm/prompts.py
+++ b/utils/llm/prompts.py
@@ -142,6 +142,8 @@ of the following stages: {stages}.
 Output a only JSON list of bounding boxes where each entry contains
 the 2D bounding box in the key "box_2d",
 and the stage name in the key "label".
+Include in the bounding boxes only the illustrations of the objects themselves,
+not any surrounding text or arrows.
 
 """
 

--- a/utils/segmentation/sam_processor.py
+++ b/utils/segmentation/sam_processor.py
@@ -136,8 +136,25 @@ class SAMClient:
                     )
                 continue
 
-            logging.pii(f"Processing bounding box for label: '{label}'")
-            bboxes.append(bbox)
+            logging.pii(
+                f"Processing bounding box for label: '{label}' "
+                f"(normalized coords: {bbox})"
+            )
+
+            # Convert normalized coordinates (0-1000) received from Qwen 3
+            # to pixel coordinates
+            bbox_pixels = [
+                (bbox[0] / 1000.0) * width,
+                (bbox[1] / 1000.0) * height,
+                (bbox[2] / 1000.0) * width,
+                (bbox[3] / 1000.0) * height
+            ]
+
+            logging.pii(
+                f"Converted to pixel coords: {bbox_pixels}"
+            )
+
+            bboxes.append(bbox_pixels)
             labels.append(label)
 
         if not bboxes:


### PR DESCRIPTION
I believe there is no corresponding issue for this — correct me if I'm wrong.
Since we've switched to Qwen 3, we are now using a normalized coordinate set (0-1000) as opposed to pixel coordinates produced by Qwen 2.5.

This fix ensures the conversion of normalized coordinates (produced by Qwen) to pixel coordinates (required by SAM).

Tested on Unicorn using examples from the IMAGE website.
---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
