### PR TITLE
fixes for text-followup not working with qwen3-vl

### DIFF
--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 IMAGE Project, Shared Reality Lab, McGill University
+# Copyright (c) 2025 IMAGE Project, Shared Reality Lab, McGill University
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -452,13 +452,16 @@ def followup():
                 {"error": "Failed to process focus area on image"}
             ), 500
 
+    # get followup prompt from env as an override if it exists
+    followup_prompt = os.getenv('FOLLOWUP_PROMPT_OVERRIDE', FOLLOWUP_PROMPT)
+
     if not focus:
-        system_prompt = FOLLOWUP_PROMPT
+        system_prompt = followup_prompt
     else:
-        system_prompt = FOLLOWUP_PROMPT + FOLLOWUP_PROMPT_FOCUS
+        system_prompt = followup_prompt + FOLLOWUP_PROMPT_FOCUS
 
     system_message = {
-        "role": "developer",
+        "role": "system",
         "content": system_prompt
         }
 
@@ -469,7 +472,7 @@ def followup():
         user_message = create_multimodal_message(user_prompt, graphic_b64)
 
         conversation_history[request_uuid] = {
-            'messages': [system_message, user_message],
+            'messages': [system_message,user_message],
             'last_updated': timestamp,
             'focus': focus if focus else None
         }
@@ -508,7 +511,9 @@ def followup():
 
     followup_response_json = llm_client.chat_completion(
         prompt="",  # Empty since we're using full messages via kwargs
-        json_schema=FOLLOWUP_RESPONSE_SCHEMA,
+        system_prompt=system_prompt,
+        json_schema=None, # qwen3 wants json_object not rigid schema
+        response_format={"type": "json_object"},
         temperature=0.0,
         messages=messages,  # Pass full conversation history via kwargs
         parse_json=True,
@@ -518,7 +523,7 @@ def followup():
     if followup_response_json is None:
         logging.error("Failed to receive response from LLM.")
         return jsonify(
-            {"error": "Failed to get graphic caption from LLM"}
+            {"error": "Failed to receive response from LLM"}
         ), 500
 
     response_text, token_usage = followup_response_json

--- a/preprocessors/text-followup/text-followup.py
+++ b/preprocessors/text-followup/text-followup.py
@@ -472,7 +472,7 @@ def followup():
         user_message = create_multimodal_message(user_prompt, graphic_b64)
 
         conversation_history[request_uuid] = {
-            'messages': [system_message,user_message],
+            'messages': [system_message, user_message],
             'last_updated': timestamp,
             'focus': focus if focus else None
         }
@@ -512,7 +512,7 @@ def followup():
     followup_response_json = llm_client.chat_completion(
         prompt="",  # Empty since we're using full messages via kwargs
         system_prompt=system_prompt,
-        json_schema=None, # qwen3 wants json_object not rigid schema
+        json_schema=None,  # qwen3 wants json_object not rigid schema
         response_format={"type": "json_object"},
         temperature=0.0,
         messages=messages,  # Pass full conversation history via kwargs

--- a/utils/llm/client.py
+++ b/utils/llm/client.py
@@ -159,8 +159,6 @@ class LLMClient:
             params.update(kwargs)
 
             logging.debug(f"Making LLM request to model: {self.model}")
-            #logging.pii(f"LLM request params: {' '.join('GRAPHIC_HIDDEN' if item == 'graphic' else item for item in params)}")
-            #logging.pii(params)
             response = self.client.chat.completions.create(**params)
 
             # Validate and extract response

--- a/utils/llm/client.py
+++ b/utils/llm/client.py
@@ -121,7 +121,7 @@ class LLMClient:
             # Add system prompt if provided
             if system_prompt:
                 messages.append(
-                    {"role": "developer",
+                    {"role": "system",
                      "content": system_prompt}
                      )
 
@@ -140,6 +140,8 @@ class LLMClient:
 
             messages.append({"role": "user", "content": user_content})
 
+            logging.pii(messages)
+
             # Build API call parameters
             params = {
                 "model": self.model,
@@ -157,6 +159,8 @@ class LLMClient:
             params.update(kwargs)
 
             logging.debug(f"Making LLM request to model: {self.model}")
+            #logging.pii(f"LLM request params: {' '.join('GRAPHIC_HIDDEN' if item == 'graphic' else item for item in params)}")
+            #logging.pii(params)
             response = self.client.chat.completions.create(**params)
 
             # Validate and extract response

--- a/utils/llm/prompts.py
+++ b/utils/llm/prompts.py
@@ -101,7 +101,8 @@ Example response:
 "response_brief": "One sentence response to the user request.",
 "response_full": "Further details. Maximum three sentences."
 }
-
+"""
+OLD_END_OF_FOLLOWUP_PROMPT = """
 The user may add a note to focus on a specific part of the image
 and an updated picture with the area of interest marked with a red rectangle.
 In this case, answer the question ONLY about the contents


### PR DESCRIPTION
resolves #1184 

There were several bugs, such as using "developer" rather than "system" for the role message history, as well as some other tweaks. However, the core issue appears to be that qwen3-vl does not like having a rigid json schema requirement. Main fix appears to be changing to "json_object" and not passing the raw schema. This would likely need to be revisited for other model families.

Tested in override on unicorn using jq script, which returned the "A" responses without fix, and seems to reliably return valid, schema-compliant json with the instructions in the current prompt:

```
jq '.followup.query = "What are the hairstyles in the photo?"' /home/venicq/follow-up.json | /var/docker/image/bin/sendimagereq /dev/stdin https:/
/unicorn.cim.mcgill.ca/image/render/preprocess/ | jq '.preprocessors."ca.mcgill.a11y.image.preprocessor.text-followup"'
```
@Samyuktha0104 also tested from monarch using override.

Other tweaks in this PR:
- re-implemented a prompt override with env variable FOLLOWUP_PROMPT_OVERRIDE, which had been lost in refactoring
- changed "developer" to "system" for system prompt role
- fixed some duplicative prompt text
- tweaks to logging and errors
- corrected copyright date

Please ensure you've followed the checklist and provide all the required information *before* requesting a review.
If you do not have everything applicable to your PR, it will not be reviewed!
If you don't know what something is or if it applies to you, ask!

Please note that PRs from external contributors who have not agreed to [our Contributor License Agreement](/CLA.md) will not be considered.
To accept it, include `I agree to the [current Contributor License Agreement](/CLA.md)` in this pull request.

Don't delete below this line.

---

## Required Information

- [x] I referenced the issue addressed in this PR.
- [x] I described the changes made and how these address the issue.
- [x] I described how I tested these changes.

## Coding/Commit Requirements

* [x] I followed applicable coding standards where appropriate (e.g., [PEP8](https://pep8.org/))
* [x] I have not committed any models or other large files.

## New Component Checklist (**mandatory** for new microservices)

* [ ] I added an entry to `docker-compose.yml` and `build.yml`.
* [ ] I created A CI workflow under `.github/workflows`.
* [ ] I have created a `README.md` file that describes what the component does and what it depends on (other microservices, ML models, etc.).

OR
* [x] I have not added a new component in this PR.
